### PR TITLE
Show remaining clicks when autoclicking a set amount

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -669,6 +669,11 @@ impl eframe::App for RustyAutoClickerApp {
                                 .desired_width(40.0f32)
                                 .hint_text("0"),
                         );
+                        if self.is_autoclicking && click_amount > 0u64 {
+                            let remaining_clicks = click_amount.saturating_sub(self.click_counter);
+                            let remaining_text = format!("Remaining {:?}", remaining_clicks);
+                            ui.label(remaining_text);
+                        }
                     });
                 });
 


### PR DESCRIPTION
When autoclicking for a set amount of X clicks, show the remaining clicks, but only while autoclicking.

(#16)

![RustyClickerRemaining](https://user-images.githubusercontent.com/30048263/195722839-f6af4d0e-00c3-4155-ad6c-08734dd27d31.gif)
