### PR TITLE
Fix autoclicking and reduce repetition

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -246,6 +246,14 @@ fn parse_string_to_u64(string: String) -> u64 {
     unsigned_int
 }
 
+fn parse_string_to_f64(string: String) -> f64 {
+    let mut float: f64 = 0f64;
+    if !string.is_empty() {
+        float = string.parse().unwrap();
+    }
+    float
+}
+
 fn autoclick(
     app_mode: AppMode,
     click_position: ClickPosition,
@@ -358,14 +366,8 @@ impl eframe::App for RustyAutoClickerApp {
         }
 
         // Parse mouse coordinates Strings to f64
-        let mut click_x: f64 = 0f64;
-        if !self.click_x_str.is_empty() {
-            click_x = self.click_x_str.parse().unwrap();
-        }
-        let mut click_y: f64 = 0f64;
-        if !self.click_y_str.is_empty() {
-            click_y = self.click_y_str.parse().unwrap();
-        }
+        let click_x: f64 = parse_string_to_f64(self.click_x_str.clone());
+        let click_y: f64 = parse_string_to_f64(self.click_y_str.clone());
 
         // Close hotkeys window if escape pressed & released
         if self.hotkey_window_open {

--- a/src/app.rs
+++ b/src/app.rs
@@ -360,10 +360,7 @@ impl eframe::App for RustyAutoClickerApp {
         // println!("{} hr {} min {} sec {} ms", &hr, min, sec, ms);
 
         // Parse click amount String to u64
-        let mut click_amount: u64 = 0u64;
-        if !self.click_amount_str.is_empty() {
-            click_amount = self.click_amount_str.parse().unwrap();
-        }
+        let click_amount: u64 = parse_string_to_u64(self.click_amount_str.clone());
 
         // Parse mouse coordinates Strings to f64
         let click_x: f64 = parse_string_to_f64(self.click_x_str.clone());

--- a/src/app.rs
+++ b/src/app.rs
@@ -238,6 +238,14 @@ fn send(event_type: &EventType) {
     }
 }
 
+fn parse_string_to_u64(string: String) -> u64 {
+    let mut unsigned_int: u64 = 0u64;
+    if !string.is_empty() {
+        unsigned_int = string.parse().unwrap();
+    }
+    unsigned_int
+}
+
 fn autoclick(
     app_mode: AppMode,
     click_position: ClickPosition,
@@ -337,22 +345,10 @@ impl eframe::App for RustyAutoClickerApp {
         sanitize_string(&mut self.click_y_str, 7usize);
 
         // Parse time Strings to u64
-        let mut hr: u64 = 0u64;
-        if !self.hr_str.is_empty() {
-            hr = self.hr_str.parse().unwrap();
-        }
-        let mut min: u64 = 0u64;
-        if !self.min_str.is_empty() {
-            min = self.min_str.parse().unwrap();
-        }
-        let mut sec: u64 = 0u64;
-        if !self.sec_str.is_empty() {
-            sec = self.sec_str.parse().unwrap();
-        }
-        let mut ms: u64 = 0u64;
-        if !self.ms_str.is_empty() {
-            ms = self.ms_str.parse().unwrap();
-        }
+        let hr: u64 = parse_string_to_u64(self.hr_str.clone());
+        let min: u64 = parse_string_to_u64(self.min_str.clone());
+        let sec: u64 = parse_string_to_u64(self.sec_str.clone());
+        let ms: u64 = parse_string_to_u64(self.ms_str.clone());
         // println!("{} hr {} min {} sec {} ms", &hr, min, sec, ms);
 
         // Parse click amount String to u64


### PR DESCRIPTION
## Refactor

- Add `parse_string_to_u64()`
- Add `parse_string_to_f64()`

## Fix

- When starting the autoclicking using the hotkey, the first click is immediately dispatched. Note: when starting the autoclicking using the button, the first click is still delayed by the click interval (that is, behavior unchanged)