### PR TITLE
ci: remove lib test job

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -69,24 +69,3 @@ jobs:
         with:
           command: check
           #args: --all-features
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Setup device_query dependencies
-        run: sudo apt-get install libx11-dev
-      - name: Setup rdev dependencies
-        run: sudo apt-get --assume-yes install libxtst-dev libevdev-dev
-      - name: Setup eframe dependencies
-        run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --lib


### PR DESCRIPTION
Remove failing `lib` test workflow job, due to removal of `lib` in #25 
https://github.com/MrTanoshii/rusty-autoclicker/blob/45961c9ead705fb5d367171d06a746f55e7cbb28/.github/workflows/rust_check.yml#L73-L92