### PR TITLE
docs(README): fetch latest version from tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 <!-- [![Latest Version](https://img.shields.io/badge/Rusty%20AutoClicker-2.2.0-blue)](https://github.com/MrTanoshii/rusty-autoclicker) -->
-[![Latest Version](https://img.shields.io/github/v/tag/MrTanoshii/rusty-autoclicker.svg?label=Version&color=orange)](https://github.com/MrTanoshii/rusty-autoclicker/releases)
+[![Latest Version](https://img.shields.io/github/v/tag/MrTanoshii/rusty-autoclicker.svg?label=Version&sort=semver&color=orange)](https://github.com/MrTanoshii/rusty-autoclicker/releases)
 [![CC0-1.0 License](https://img.shields.io/badge/License-CC0--1.0-blue)](https://github.com/MrTanoshii/rusty-autoclicker/blob/main/LICENSE)
 [![Rust Check](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/rust_check.yml/badge.svg)](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/rust_check.yml)
 [![Linux Build](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/linux_build.yml/badge.svg)](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/linux_build.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <div align="center">
 
-[![Latest Version](https://img.shields.io/badge/Rusty%20AutoClicker-2.2.0-blue)](https://github.com/MrTanoshii/rusty-autoclicker)
+<!-- [![Latest Version](https://img.shields.io/badge/Rusty%20AutoClicker-2.2.0-blue)](https://github.com/MrTanoshii/rusty-autoclicker) -->
+[![Latest Version](https://img.shields.io/github/v/tag/MrTanoshii/rusty-autoclicker.svg?label=Version&color=orange)](https://github.com/MrTanoshii/rusty-autoclicker/releases)
 [![CC0-1.0 License](https://img.shields.io/badge/License-CC0--1.0-blue)](https://github.com/MrTanoshii/rusty-autoclicker/blob/main/LICENSE)
 [![Rust Check](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/rust_check.yml/badge.svg)](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/rust_check.yml)
 [![Linux Build](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/linux_build.yml/badge.svg)](https://github.com/MrTanoshii/rusty-autoclicker/actions/workflows/linux_build.yml)


### PR DESCRIPTION
No need to manually bump version number in `README`