### PR TITLE
fix reported mouse buttons Left/Middle/Right instead of Left/Right/Middle

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -489,7 +489,7 @@ impl eframe::App for RustyAutoClickerApp {
                     .join(" ");
 
                 ui.label(format!(
-                    "Mouse pressed: L-{:?} R-{:?} M-{:?} {}",
+                    "Mouse pressed: L-{:?} M-{:?} R-{:?} {}",
                     mouse.button_pressed[1],
                     mouse.button_pressed[2],
                     mouse.button_pressed[3],


### PR DESCRIPTION

tested on linux with two different mouses