### PR TITLE
build: fix build for native MinGW build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,9 @@
-use std::io;
 use winresource::WindowsResource;
 
-fn main() -> io::Result<()> {
-    if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "windows" {
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
         let mut res = WindowsResource::new();
-        let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-        let host = std::env::var("HOST").unwrap();
-        match env.as_str() {
-            "gnu" => {
-                // Set proper binutils for cross-compilation
-                if !host.contains("windows-gnu") {
-                    res.set_ar_path("x86_64-w64-mingw32-ar")
-                        .set_windres_path("x86_64-w64-mingw32-windres");
-                }
-            }
-            "msvc" => {}
-            _ => panic!("unsupported target-env: {env}"),
-        };
-        res.set_icon("assets/icon-256.ico");
-        res.compile()?;
+        res.set_icon("assets/icon-256.ico").set_language(0x0409); // English (US)
+        res.compile().unwrap();
     }
-    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -5,12 +5,14 @@ fn main() -> io::Result<()> {
     if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "windows" {
         let mut res = WindowsResource::new();
         let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        let host = std::env::var("HOST").unwrap();
         match env.as_str() {
             "gnu" => {
-                // Not sure whether this works the same if build on windows; needs testing
-                // Perfectly fine if cross compiling from linux
-                res.set_ar_path("x86_64-w64-mingw32-ar")
-                    .set_windres_path("x86_64-w64-mingw32-windres");
+                // Set proper binutils for cross-compilation
+                if !host.contains("windows-gnu") {
+                    res.set_ar_path("x86_64-w64-mingw32-ar")
+                        .set_windres_path("x86_64-w64-mingw32-windres");
+                }
             }
             "msvc" => {}
             _ => panic!("unsupported target-env: {env}"),


### PR DESCRIPTION
I tried to build for MSYS2 environment, and it failed, because of windres being available only as `windres` (without target triple). so don't set such names for host == target build