### PR TITLE
v2.5.6: New key capture, random offset, responsive UI, & bug fixes

### DIFF
--- a/CHANGELOG_2.5.2.md
+++ b/CHANGELOG_2.5.2.md
@@ -1,0 +1,133 @@
+# Rusty AutoClicker v2.5.2 — Changelog
+
+This release adds full settings persistence, a completely reworked coordinate
+picker (crash-safe under minimize/rapid input, matches other apps as an
+overlay), a Save/Reset workflow, and several correctness/performance fixes.
+Version bumped from 2.5.1 → 2.5.2.
+
+## New: Settings Persistence
+
+- Added `src/settings.rs` with a `Settings` struct that captures every
+  user-configurable value: hotkeys, click coordinates, timing fields
+  (hr/min/sec/ms), tween speed range, click amount, click button/type/
+  position, app mode, and window geometry (size + position).
+- Settings are stored as JSON at `%APPDATA%/rusty-autoclicker/settings.json`
+  (via the `dirs` crate for cross-platform config-dir resolution).
+- Hotkeys round-trip through `device_query::Keycode`'s own `Display`/
+  `FromStr`. `ClickButton` gets a small custom string mapping
+  (`to_setting_string` / `from_setting_string`) since `rdev::Button`/`Key`
+  don't implement `serde` traits directly.
+- New dependencies: `serde`, `serde_json`, `dirs`.
+
+## New: Manual Save / Reset Workflow
+
+- Removed continuous "save every frame if changed" auto-save entirely.
+- Added a **Save** button (💾) in the top bar — writes all current settings
+  to disk immediately, on demand.
+- Added a **Reset** button (↺) in the top bar — restores every setting to
+  its documented default, resizes the window back to its default size,
+  re-centers it on the actual screen resolution, and saves immediately.
+- **Window size and position are the one exception that still auto-saves**,
+  but only once, in `Drop` (on app close) — not continuously. This keeps a
+  manually-resized/moved window remembered across restarts without
+  reintroducing per-frame disk writes.
+- Fixed startup flicker: the saved window position/size (or, on first
+  launch, a computed screen-center position) is now passed directly into
+  `ViewportBuilder` in `main.rs` *before* the window is created, so the
+  window never flashes at a default position and then jumps.
+- Fixed true screen-centering: switched from manually computing center via
+  `viewport().monitor_size` (documented as commonly `None`/unreliable) to
+  egui's own `ViewportCommand::center_on_screen`. This now runs both on
+  **Reset** and on **first launch** (previously first launch fell back to a
+  hardcoded `(100, 100)` corner).
+
+## New: "Set Coords" Hotkey
+
+- Added a dedicated hotkey (default **F10**) to open the coordinate picker,
+  as a shortcut for the existing manual "Set Coords" button — both now go
+  through the same code path.
+- Added to the Hotkeys window UI, positioned below Start/Stop and above
+  Confirm Coords, with its own "PRESS ANY KEY" capture flow matching the
+  other three hotkeys.
+- Default hotkeys (all rebindable): Start/Stop = `F6`, Set Coords = `F10`,
+  Confirm Coords = `Escape` / Left Click, Click & Hold = `F7`.
+
+## Reworked: Coordinate Picker Architecture
+
+The single biggest change this release. The old picker worked by resizing
+the **main window itself** down to a small borderless overlay (400×30),
+then restoring it after confirmation. This caused several serious bugs when
+combined with the new F10 hotkey and minimize support:
+
+- Main window would sometimes shrink permanently to the picker's tiny size
+  under rapid F10 + confirm spam.
+- Using F10 while the app was minimized would pop the main window back up,
+  with a visible OS minimize/restore animation.
+- Under rapid input, this could crash.
+
+**Fix:** the coordinate picker is now rendered in its own **independent
+egui viewport** (`ctx.show_viewport_deferred`, driven from `logic()` so it
+keeps working even while the main window is minimized), completely separate
+from the main window:
+
+- Fixed size, currently **400×65**, defined as `COORD_PICKER_SIZE` in
+  `src/gui/windows.rs` — never resized by any code path, and
+  `.with_resizable(false)` prevents the user from dragging it larger/
+  smaller either.
+- `.with_always_on_top()` so it overlays other applications on screen, like
+  the original picker behavior.
+- Visual style rebuilt to match the original overlay exactly: `Panel::top`
+  + `MenuBar` + `horizontal_wrapped` in a `right_to_left` layout, with the
+  original widget order (Y-edit, "Y", X-edit, "X", separator, "Set with…"
+  label), using the app's normal dark theme rather than a manually painted
+  black box.
+- Real-time X/Y tracking fixed: the picker's own viewport closure now calls
+  `request_repaint()` on itself every frame (a self-sustaining repaint
+  loop), rather than relying solely on the parent nudging it — the latter
+  proved unreliable and caused the coordinates to appear frozen.
+- Data is shared between the main app and the picker's viewport via
+  `Arc<Mutex<CoordPickerShared>>` (mouse position + confirm hotkey), since
+  deferred-viewport callbacks must be `Send + Sync + 'static` and can't
+  borrow `&mut self`.
+- New behavior on entering coordinate-setting mode: if the main window is
+  currently **visible**, it's automatically minimized so only the picker is
+  on screen while picking, then restored to its exact prior state once
+  coordinates are confirmed. If the main window is **already minimized**
+  when F10 fires, it's left untouched throughout — no pop-up, no animation,
+  no resize, no matter how rapidly F10 or confirm are pressed.
+
+## Performance
+
+- `device_query::DeviceState` is now created **once** (in
+  `Default::default()`) and reused every frame, instead of being
+  reconstructed on every single `logic()` call.
+- `track_window_geometry` (which persists the main window's size/position)
+  is now explicitly guarded to only ever read the **root** viewport's
+  geometry (`ctx.viewport_id() == egui::ViewportId::ROOT`), preventing a
+  rare timing edge case where it could transiently read the picker
+  viewport's tiny geometry instead and persist that as the main window's
+  size.
+- `ctx.request_repaint()` is called unconditionally every frame so hotkeys
+  are never delayed by a sleep — egui already throttles this to the
+  display's refresh rate, so it doesn't increase CPU usage beyond normal.
+
+## Defaults Changed
+
+- Click interval default: `100ms` → `200ms`.
+- Main window default size: `550×341` → `580×340`.
+- Coordinate picker fixed size: `400×65`.
+- Click coordinate defaults remain `0, 0` (unrelated to window position).
+
+## Cleanup
+
+- Removed an unused/dead field (`key_pressed_set_coord`) that was written
+  but never read anywhere.
+- Removed unused imports left over from earlier iterations of the
+  coordinate-picker rework.
+
+---
+
+### Files touched
+`Cargo.toml`, `src/main.rs`, `src/defines.rs`, `src/types.rs`, `src/app.rs`,
+`src/settings.rs` (new), `src/gui/mod.rs`, `src/gui/windows.rs`,
+`src/gui/sections/bars.rs`, `src/gui/sections/click_config.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1372,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -2489,6 +2521,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +2999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,15 +3117,18 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-autoclicker"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "device_query",
+ "dirs",
  "eframe",
  "image",
  "native-dialog",
  "rand",
  "rdev",
  "sanitizer",
+ "serde",
+ "serde_json",
  "winresource",
 ]
 
@@ -3701,6 +3753,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-autoclicker"
-version = "2.5.2"
+version = "2.5.6"
 dependencies = [
  "device_query",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-autoclicker"
-version = "2.5.1"
+version = "2.5.2"
 repository = "https://github.com/MrTanoshii/rusty-autoclicker"
 readme = "README.md"
 rust-version = "1.96"
@@ -11,6 +11,7 @@ edition = "2024"
 
 [dependencies]
 device_query = "4.0.1"
+dirs = "6"
 eframe = { version = "0.34.3", default-features = false, features = [
     "accesskit",
     "default_fonts",
@@ -23,6 +24,8 @@ native-dialog = "0.9"
 rand = "0.10.1"
 rdev = "0.5"
 sanitizer = { version = "1.0.0", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [build-dependencies]
 winresource = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-autoclicker"
-version = "2.5.2"
+version = "2.5.6"
 repository = "https://github.com/MrTanoshii/rusty-autoclicker"
 readme = "README.md"
 rust-version = "1.96"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,18 +1,33 @@
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use device_query::{Keycode, MouseState};
+use device_query::{DeviceState, Keycode, MouseState};
 use eframe::{egui, epaint::FontId};
 use rand::{prelude::ThreadRng, rng};
 use rdev::Button;
 
 use crate::{
     defines::*,
+    settings::{self, Settings},
     types::{AppMode, ClickButton, ClickPosition, ClickType, InteractionMode},
     utils::{
         interval_ms, move_mouse_to, press_button, release_button, sanitize_i64_string,
         sanitize_string,
     },
 };
+
+/// Live data the coordinate-picker's independent (deferred) viewport reads
+/// every frame to know where to draw itself. Shared via `Arc<Mutex<..>>`
+/// because `show_viewport_deferred` requires a `Send + Sync + 'static`
+/// callback — unlike `show_viewport_immediate`, it cannot borrow `&mut
+/// self` directly, since it is designed to run independently of the
+/// call site's frame lifecycle (which is exactly what makes it safe to
+/// drive from `logic()`, and safe under rapid F10 spam).
+#[derive(Default, Clone, Copy)]
+pub struct CoordPickerShared {
+    pub pos: (i32, i32),
+    pub confirm_key: Option<Keycode>,
+}
 
 pub struct RustyAutoClickerApp {
     // Text input strings
@@ -35,6 +50,7 @@ pub struct RustyAutoClickerApp {
 
     // Hotkeys
     pub key_autoclick: Option<Keycode>,
+    pub key_open_set_coord: Option<Keycode>,
     pub key_set_coord: Option<Keycode>,
     pub key_hold: Option<Keycode>,
 
@@ -49,11 +65,29 @@ pub struct RustyAutoClickerApp {
 
     // Window state
     pub hotkey_window_open: bool,
-    pub window_position: egui::Pos2,
 
-    // Key states
+    /// True only when THIS app auto-minimized the main window itself upon
+    /// entering coordinate-setting mode (because it was visible at the
+    /// time). Used so `exit_coordinate_setting` only un-minimizes the
+    /// window if we're the ones who minimized it — if the window was
+    /// already minimized before F10 was pressed, it correctly stays
+    /// minimized after confirming coordinates too.
+    pub auto_minimized_for_picker: bool,
+
+    /// Last known inner window size [w, h] in logical pixels, for the MAIN
+    /// window only. Updated every frame. The coordinate picker lives in its
+    /// own viewport and never writes to this field, so it can never leak
+    /// its own (much smaller) size into the persisted/main geometry.
+    pub last_window_size: [f32; 2],
+
+    /// Last known outer window position [x, y] in logical pixels, for the
+    /// MAIN window only. Same "never touched by the picker" guarantee as
+    /// `last_window_size` above.
+    pub last_window_pos: egui::Pos2,
+
+    // Key-down edge-detection flags
     pub key_pressed_autoclick: bool,
-    pub key_pressed_set_coord: bool,
+    pub key_pressed_open_set_coord: bool,
     pub key_pressed_esc: bool,
     pub key_pressed_hold: bool,
     pub keys_pressed: Option<Vec<Keycode>>,
@@ -65,14 +99,22 @@ pub struct RustyAutoClickerApp {
     pub click_btn: ClickButton,
     pub click_type: ClickType,
     pub click_position: ClickPosition,
+
     // RNG
     pub rng_thread: ThreadRng,
+
+    /// Cached device-state poller — created once and reused every frame
+    /// instead of being constructed anew in every `logic()` call.
+    pub device_state: DeviceState,
+
+    /// Shared with the coordinate-picker's deferred viewport (see
+    /// `gui/windows.rs::show_coord_picker_viewport`).
+    pub coord_picker_shared: Arc<Mutex<CoordPickerShared>>,
 }
 
 impl Default for RustyAutoClickerApp {
     fn default() -> Self {
         Self {
-            // Text input strings
             hr_str: DEFAULT_HR_STR.to_owned(),
             min_str: DEFAULT_MIN_STR.to_owned(),
             sec_str: DEFAULT_SEC_STR.to_owned(),
@@ -83,48 +125,40 @@ impl Default for RustyAutoClickerApp {
             speed_min_str: MOUSE_TWEEN_SPEED_MIN_PX_S.to_string(),
             speed_max_str: MOUSE_TWEEN_SPEED_MAX_PX_S.to_string(),
 
-            // Time
             last_now: Instant::now(),
             frame_start: Instant::now(),
 
-            // Counter
             click_counter: 0u64,
 
-            // Hotkeys
             key_autoclick: HOTKEY_AUTOCLICK,
+            key_open_set_coord: HOTKEY_OPEN_SET_COORD,
             key_set_coord: HOTKEY_SET_COORD,
             key_hold: HOTKEY_HOLD,
 
-            // Interaction state
             mode: InteractionMode::Idle,
-
-            // No button held initially
             held_button: None,
-
-            // App mode
             app_mode: AppMode::Bot,
 
-            // Window state
             hotkey_window_open: false,
-            window_position: egui::Pos2 { x: 0f32, y: 0f32 },
+            auto_minimized_for_picker: false,
+            last_window_size: [WINDOW_WIDTH, WINDOW_HEIGHT],
+            last_window_pos: egui::pos2(WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y),
 
-            // Key states
             key_pressed_autoclick: false,
-            key_pressed_set_coord: false,
+            key_pressed_open_set_coord: false,
             key_pressed_esc: false,
             key_pressed_hold: false,
             keys_pressed: None,
 
-            // Mouse snapshot
             mouse: MouseState::default(),
 
-            // Enums
             click_btn: ClickButton::Mouse(Button::Left),
             click_type: ClickType::Single,
             click_position: ClickPosition::Mouse,
 
-            // RNG
             rng_thread: rng(),
+            device_state: DeviceState::new(),
+            coord_picker_shared: Arc::new(Mutex::new(CoordPickerShared::default())),
         }
     }
 }
@@ -134,74 +168,164 @@ impl RustyAutoClickerApp {
         let ctx = &cc.egui_ctx;
 
         let mut style = (*ctx.global_style()).clone();
-        let font = FontId {
-            size: FONT_SIZE,
-            family: FONT_FAMILY,
-        };
-        style.override_font_id = Some(font);
+        style.override_font_id = Some(FontId { size: FONT_SIZE, family: FONT_FAMILY });
         ctx.set_global_style(style);
 
-        Default::default()
-    }
+        let mut app = Self::default();
 
-    /// Whether an autoclick run is currently in progress.
-    pub fn is_autoclicking(&self) -> bool {
-        matches!(self.mode, InteractionMode::Autoclicking)
-    }
+        let mut had_saved_position = false;
 
-    /// Whether a button is currently held down via click-and-hold.
-    pub fn is_holding(&self) -> bool {
-        matches!(self.mode, InteractionMode::Holding)
-    }
+        if let Some(loaded) = settings::load_settings() {
+            loaded.apply_to(&mut app);
 
-    /// Whether interactive widgets should be disabled: an autoclick run or a
-    /// click-and-hold is in progress, or the hotkeys window is open.
-    pub fn is_busy(&self) -> bool {
-        self.is_autoclicking() || self.is_holding() || self.hotkey_window_open
-    }
+            // Restore window size — sent as a viewport command here; the OS
+            // will apply it before the first frame is painted. This is a
+            // one-time startup restore, not a "resize" in the runtime sense
+            // the user cares about, so it's exempt from the
+            // "only user/Reset may resize" rule.
+            if let Some([w, h]) = loaded.window_size {
+                app.last_window_size = [w, h];
+                ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(w, h)));
+            }
 
-    /// Whether the app is idle: not autoclicking and not in any key-capture or
-    /// coordinate-setting mode.
-    pub fn is_idle(&self) -> bool {
-        matches!(self.mode, InteractionMode::Idle)
-    }
-
-    /// Disable the remaining widgets in `ui`'s current container while the app
-    /// [`is_busy`](Self::is_busy). egui's `disable()` is container-scoped and
-    /// permanent, so this mirrors the inline guard it replaces.
-    pub fn disable_if_busy(&self, ui: &mut egui::Ui) {
-        if self.is_busy() {
-            ui.disable();
+            // Restore window position. We send this command here so the
+            // OS can position the window before the first paint, eliminating
+            // the startup flicker where the window briefly appears at the
+            // default position.
+            if let Some([x, y]) = loaded.window_position {
+                let pos = egui::pos2(x, y);
+                app.last_window_pos = pos;
+                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(pos));
+                had_saved_position = true;
+            }
         }
+
+        // Fresh install / no saved position yet: center on the actual
+        // screen resolution, same as the Reset button does, instead of the
+        // old hardcoded WINDOW_DEFAULT_X/Y fallback. Still sent before the
+        // first frame paints, so there's no flicker on first launch either.
+        if !had_saved_position {
+            if let Some(cmd) = egui::ViewportCommand::center_on_screen(ctx) {
+                if let egui::ViewportCommand::OuterPosition(pos) = cmd {
+                    app.last_window_pos = pos;
+                }
+                ctx.send_viewport_cmd(cmd);
+            }
+        }
+
+        app
     }
 
-    /// Label for the start/stop autoclick button, e.g. `🖱 START (F6)`,
-    /// `🖱 STOP (F6)`, or `🖱 START` when no hotkey is set.
+    // -----------------------------------------------------------------------
+    // Settings
+    // -----------------------------------------------------------------------
+
+    /// Write the current settings to disk immediately (Save button).
+    pub fn save_settings_now(&self) {
+        settings::save_settings(&Settings::from_app(self));
+    }
+
+    /// Reset every user-configurable setting to its default value,
+    /// resize the window back to the default size, and move it to the
+    /// default position. Persists immediately so the reset survives the next launch.
+    ///
+    /// This is one of exactly two places in the whole app allowed to resize
+    /// the main window at runtime (the other being a manual drag by the
+    /// user, which egui/the OS handles directly and never goes through this
+    /// code at all).
+    pub fn reset_to_defaults(&mut self, ctx: &egui::Context) {
+        self.hr_str = DEFAULT_HR_STR.to_owned();
+        self.min_str = DEFAULT_MIN_STR.to_owned();
+        self.sec_str = DEFAULT_SEC_STR.to_owned();
+        self.ms_str = DEFAULT_MS_STR.to_owned();
+        self.click_amount_str = DEFAULT_CLICK_AMOUNT_STR.to_owned();
+        self.click_x_str = DEFAULT_CLICK_X_STR.to_owned();
+        self.click_y_str = DEFAULT_CLICK_Y_STR.to_owned();
+        self.speed_min_str = MOUSE_TWEEN_SPEED_MIN_PX_S.to_string();
+        self.speed_max_str = MOUSE_TWEEN_SPEED_MAX_PX_S.to_string();
+
+        self.key_autoclick = HOTKEY_AUTOCLICK;
+        self.key_open_set_coord = HOTKEY_OPEN_SET_COORD;
+        self.key_set_coord = HOTKEY_SET_COORD;
+        self.key_hold = HOTKEY_HOLD;
+
+        self.click_btn = ClickButton::Mouse(Button::Left);
+        self.click_type = ClickType::Single;
+        self.click_position = ClickPosition::Mouse;
+        self.app_mode = AppMode::Bot;
+
+        // Resize back to the original window size and move it back to the
+        // true center of the screen it's currently on. We use egui's own
+        // `ViewportCommand::center_on_screen` helper rather than manually
+        // reading `viewport().monitor_size` — that field is documented as
+        // commonly `None`/unreliable depending on platform and timing, which
+        // is the most likely reason centering silently fell back to
+        // WINDOW_DEFAULT_X/Y in practice. `center_on_screen` is egui's own
+        // built-in, more robust implementation of exactly this.
+        // WINDOW_DEFAULT_X/Y remains as the last-resort fallback for the
+        // rare case egui itself can't determine placement.
+        self.last_window_size = [WINDOW_WIDTH, WINDOW_HEIGHT];
+        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
+            WINDOW_WIDTH,
+            WINDOW_HEIGHT,
+        )));
+        match egui::ViewportCommand::center_on_screen(ctx) {
+            Some(cmd) => {
+                if let egui::ViewportCommand::OuterPosition(pos) = cmd {
+                    self.last_window_pos = pos;
+                }
+                ctx.send_viewport_cmd(cmd);
+            }
+            None => {
+                let fallback = egui::pos2(WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y);
+                self.last_window_pos = fallback;
+                ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(fallback));
+            }
+        }
+
+        self.save_settings_now();
+    }
+
+    // -----------------------------------------------------------------------
+    // State queries
+    // -----------------------------------------------------------------------
+
+    pub fn is_autoclicking(&self) -> bool { matches!(self.mode, InteractionMode::Autoclicking) }
+    pub fn is_holding(&self) -> bool { matches!(self.mode, InteractionMode::Holding) }
+    pub fn is_setting_coord(&self) -> bool { matches!(self.mode, InteractionMode::SettingCoord) }
+    pub fn is_busy(&self) -> bool {
+        self.is_autoclicking() || self.is_holding() || self.hotkey_window_open || self.is_setting_coord()
+    }
+    pub fn is_idle(&self) -> bool { matches!(self.mode, InteractionMode::Idle) }
+
+    pub fn disable_if_busy(&self, ui: &mut egui::Ui) {
+        if self.is_busy() { ui.disable(); }
+    }
+
+    // -----------------------------------------------------------------------
+    // Labels
+    // -----------------------------------------------------------------------
+
     pub fn autoclick_button_label(&self) -> String {
-        let verb = if self.is_autoclicking() {
-            "STOP"
-        } else {
-            "START"
-        };
+        let verb = if self.is_autoclicking() { "STOP" } else { "START" };
         match self.key_autoclick {
-            Some(hotkey) => format!("🖱 {verb} ({hotkey})"),
+            Some(k) => format!("🖱 {verb} ({k})"),
             None => format!("🖱 {verb}"),
         }
     }
 
-    /// Label for the click-and-hold button, e.g. `HOLD (F7)`,
-    /// `RELEASE (F7)`, or `HOLD` when no hotkey is set.
     pub fn hold_button_label(&self) -> String {
         let verb = if self.is_holding() { "RELEASE" } else { "HOLD" };
         match self.key_hold {
-            Some(hotkey) => format!("{verb} ({hotkey})"),
+            Some(k) => format!("{verb} ({k})"),
             None => verb.to_string(),
         }
     }
 
-    /// Sanitize all numeric input strings in place: the time, amount, and
-    /// speed fields accept digits only; the X/Y coordinate fields accept a
-    /// signed integer.
+    // -----------------------------------------------------------------------
+    // Input sanitization / parsing
+    // -----------------------------------------------------------------------
+
     pub fn sanitize_inputs(&mut self) {
         sanitize_string(&mut self.hr_str, INPUT_LEN_TIME);
         sanitize_string(&mut self.min_str, INPUT_LEN_TIME);
@@ -214,7 +338,6 @@ impl RustyAutoClickerApp {
         sanitize_string(&mut self.speed_max_str, INPUT_LEN_TIME);
     }
 
-    /// Total click interval in milliseconds, parsed from the hr/min/sec/ms fields.
     pub fn parsed_interval_ms(&self) -> u64 {
         interval_ms(
             self.hr_str.parse().unwrap_or_default(),
@@ -224,30 +347,14 @@ impl RustyAutoClickerApp {
         )
     }
 
-    /// Humanlike glide speed range in px/s, parsed from the speed fields.
-    /// Empty input falls back to the defaults; the minimum is kept at least
-    /// 1 px/s and the maximum at least the minimum, so the range is never
-    /// empty or zero.
     pub fn parsed_speed_range(&self) -> (f64, f64) {
-        let min = self
-            .speed_min_str
-            .parse()
-            .unwrap_or(MOUSE_TWEEN_SPEED_MIN_PX_S)
-            .max(1.0);
-        let max = self
-            .speed_max_str
-            .parse()
-            .unwrap_or(MOUSE_TWEEN_SPEED_MAX_PX_S)
-            .max(min);
+        let min = self.speed_min_str.parse().unwrap_or(MOUSE_TWEEN_SPEED_MIN_PX_S).max(1.0);
+        let max = self.speed_max_str.parse().unwrap_or(MOUSE_TWEEN_SPEED_MAX_PX_S).max(min);
         (min, max)
     }
 
-    /// Number of clicks to perform; `0` means "click forever".
-    pub fn parsed_click_amount(&self) -> u64 {
-        self.click_amount_str.parse().unwrap_or_default()
-    }
+    pub fn parsed_click_amount(&self) -> u64 { self.click_amount_str.parse().unwrap_or_default() }
 
-    /// Target click coordinates, parsed from the X/Y fields.
     pub fn parsed_click_coord(&self) -> (f64, f64) {
         (
             self.click_x_str.parse().unwrap_or_default(),
@@ -255,65 +362,74 @@ impl RustyAutoClickerApp {
         )
     }
 
-    /// Enter the coordinate setting mode
-    ///
-    /// # Arguments
-    ///
-    /// * `ctx` - The ctx to manipulate
+    // -----------------------------------------------------------------------
+    // Coordinate-setting mode
+    // -----------------------------------------------------------------------
+    //
+    // The coordinate picker is ALWAYS rendered in its own independent egui
+    // viewport (see `gui/windows.rs::show_coord_picker_viewport`) at a fixed
+    // 500x32 size — it is never resized, in any code path, ever.
+    //
+    // The MAIN window itself is never resized here either. The only thing
+    // this code does to the main window is minimize/restore it:
+    //   * If the main window is VISIBLE when F10 fires, we minimize it so
+    //     only the picker is on screen while picking, then restore it (un-
+    //     minimize, back to its exact prior size/position — the OS remembers
+    //     that) once coordinates are confirmed.
+    //   * If the main window is ALREADY minimized when F10 fires, we leave
+    //     it alone entirely — it stays minimized before, during, and after
+    //     picking. No restore, no animation, no pop-up.
+    // `auto_minimized_for_picker` is what makes this distinction: it's only
+    // `true` when THIS code performed the minimize, so only then do we
+    // reverse it on exit.
+
+    /// Returns `true` when the OS reports the main window as minimized.
+    pub fn is_window_minimized(ctx: &egui::Context) -> bool {
+        ctx.input(|i| i.viewport().minimized).unwrap_or(false)
+    }
+
+    /// Enter coordinate-setting mode. If the main window is currently
+    /// visible, minimize it (so only the fixed-size picker is on screen);
+    /// if it's already minimized, leave it exactly as-is.
     pub fn enter_coordinate_setting(&mut self, ctx: &egui::Context) {
+        if !self.is_idle() {
+            return;
+        }
         self.mode = InteractionMode::SettingCoord;
-        self.window_position =
-            ctx.input(|input_state| input_state.viewport().outer_rect.unwrap().min);
-        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(400f32, 30f32)));
-        ctx.send_viewport_cmd(egui::ViewportCommand::Decorations(false));
+
+        if Self::is_window_minimized(ctx) {
+            self.auto_minimized_for_picker = false;
+        } else {
+            self.auto_minimized_for_picker = true;
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(true));
+        }
     }
 
-    /// Make frame follow cursor with an offset
-    ///
-    /// # Arguments
-    ///
-    /// * `ctx` - The ctx to set the window position on
-    pub fn follow_cursor(&mut self, ctx: &egui::Context) {
-        let offset = egui::Vec2 { x: 15f32, y: 15f32 };
-        let (click_x, click_y) = self.parsed_click_coord();
-        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(
-            egui::pos2(click_x as f32, click_y as f32) + offset,
-        ));
-    }
-
-    /// Exit the coordinate setting mode
-    ///
-    /// # Arguments
-    ///
-    /// * `ctx` - The ctx to manipulate
+    /// Exit coordinate-setting mode. Restores the main window from minimized
+    /// only if `enter_coordinate_setting` was the one that minimized it.
     pub fn exit_coordinate_setting(&mut self, ctx: &egui::Context) {
-        ctx.send_viewport_cmd(egui::ViewportCommand::Decorations(true));
-        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
-            WINDOW_WIDTH,
-            WINDOW_HEIGHT,
-        )));
-        ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(self.window_position));
-
         self.mode = InteractionMode::Idle;
         self.click_position = ClickPosition::Coord;
+
+        if self.auto_minimized_for_picker {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Minimized(false));
+        }
+        self.auto_minimized_for_picker = false;
     }
 
-    /// Start the autoclicking process
-    ///
-    /// # Arguments
-    ///
-    /// * `negative_click_start_offset` - The offset to start the click counter at
+    // -----------------------------------------------------------------------
+    // Autoclick / hold
+    // -----------------------------------------------------------------------
+
     pub fn start_autoclick(&mut self, negative_click_start_offset: u64) {
         self.click_counter = 0u64;
         self.mode = InteractionMode::Autoclicking;
         self.rng_thread = rng();
-
         self.last_now = Instant::now()
             .checked_sub(Duration::from_millis(negative_click_start_offset))
             .unwrap();
     }
 
-    /// Press the currently selected button down and hold it.
     pub fn start_hold(&mut self) {
         if self.click_position == ClickPosition::Coord {
             move_mouse_to(
@@ -329,7 +445,6 @@ impl RustyAutoClickerApp {
         self.mode = InteractionMode::Holding;
     }
 
-    /// Release the held button (if any) and return to idle.
     pub fn stop_hold(&mut self) {
         if let Some(button) = self.held_button.take() {
             release_button(button);
@@ -339,12 +454,17 @@ impl RustyAutoClickerApp {
 }
 
 impl Drop for RustyAutoClickerApp {
-    /// Release any button still held when the app shuts down, so quitting
-    /// mid-hold never leaves a button stuck pressed at the OS level. (Does not
-    /// run on a release-build panic, since `panic = "abort"`.)
+    /// On close: release any held button, then write the final window
+    /// geometry (size + position) to disk without touching other settings.
     fn drop(&mut self) {
         if let Some(button) = self.held_button.take() {
             release_button(button);
         }
+        settings::save_window_geometry(
+            self.last_window_size[0],
+            self.last_window_size[1],
+            self.last_window_pos.x,
+            self.last_window_pos.y,
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, Instant};
 
 use device_query::{DeviceState, Keycode, MouseState};
 use eframe::{egui, epaint::FontId};
-use rand::{prelude::ThreadRng, rng};
-use rdev::Button;
+use rand::{RngExt, prelude::ThreadRng, rng};
+use rdev::{Button, Key};
 
 use crate::{
     defines::*,
@@ -40,6 +40,20 @@ pub struct RustyAutoClickerApp {
     pub click_y_str: String,
     pub speed_min_str: String,
     pub speed_max_str: String,
+
+    // Random offset (+/- jitter applied to the click interval)
+    pub random_offset_enabled: bool,
+    pub random_offset_str: String,
+
+    /// The actual interval (ms) the current wait cycle is timing against —
+    /// the base Click Interval, jittered by `random_offset_str` when
+    /// `random_offset_enabled` is on. Rolled to a fresh random value once
+    /// per cycle (`start_autoclick`, and after every successful click in
+    /// `dispatch_click`) rather than every frame, so a click fires at one
+    /// consistent randomly-chosen interval instead of effectively always
+    /// firing at whatever the smallest interval sampled across polling
+    /// frames happened to be.
+    pub current_interval_ms: u64,
 
     // Time
     pub last_now: Instant,
@@ -80,6 +94,17 @@ pub struct RustyAutoClickerApp {
     /// its own (much smaller) size into the persisted/main geometry.
     pub last_window_size: [f32; 2],
 
+    /// The uniform scale factor derived from `last_window_size` vs the
+    /// default [`WINDOW_WIDTH`]/[`WINDOW_HEIGHT`], recomputed once per
+    /// frame at the top of `ui()` and applied globally to font size and
+    /// `egui::Style::spacing` there. Section functions in
+    /// `gui/sections/*.rs` also read it directly to scale their own
+    /// explicit field/button sizes (which aren't covered by `Style`) by
+    /// the same factor, so the whole UI — text, padding, controls, field
+    /// widths — shrinks and grows together as one unit instead of each
+    /// piece scaling independently.
+    pub ui_scale: f32,
+
     /// Last known outer window position [x, y] in logical pixels, for the
     /// MAIN window only. Same "never touched by the picker" guarantee as
     /// `last_window_size` above.
@@ -99,6 +124,49 @@ pub struct RustyAutoClickerApp {
     pub click_btn: ClickButton,
     pub click_type: ClickType,
     pub click_position: ClickPosition,
+
+    /// Set while `mode == InteractionMode::SettingClickKey` when the last
+    /// captured key couldn't be used — either it's already bound to one of
+    /// the F6/F7/F10/etc. hotkeys, or it has no `rdev::Key` counterpart in
+    /// the click-button dropdown (see `utils::keycode_to_rdev_key`).
+    /// Cleared on entering capture mode and on a successful capture.
+    pub click_key_capture_error: Option<String>,
+
+    /// Set after a SUCCESSFUL capture, shown until the next capture starts.
+    /// Exists so setting a key that happens to match the one already
+    /// selected still gives visible confirmation — without this, that case
+    /// produces no visible change anywhere (the dropdown text is identical
+    /// to before), which otherwise looks exactly like nothing happened.
+    pub click_key_capture_feedback: Option<String>,
+
+    /// When `click_key_capture_feedback` was set, so it can auto-clear
+    /// after `CLICK_KEY_FEEDBACK_TIMEOUT_SECS` instead of sitting there
+    /// forever (or, worse, still showing the PREVIOUS key's message after
+    /// you've since switched to Mouse mode or picked a different key).
+    pub click_key_capture_feedback_set_at: Option<Instant>,
+
+    /// The last `rdev::Key` selected in Keyboard mode (via the dropdown OR
+    /// Press-Key capture), remembered independently of `click_btn` so that
+    /// toggling Mouse -> Keyboard restores it instead of always resetting
+    /// to Space. Session-only by default; persisted to disk like every
+    /// other setting only when the Save button is used, and reset back to
+    /// `Key::Space` by the Reset button — same rules as everything else.
+    pub last_keyboard_key: Key,
+
+    /// `click_btn` as of the end of the PREVIOUS frame, used by
+    /// `show_buttons` to detect "did the key actually change" for the
+    /// "Set to X" feedback message.
+    ///
+    /// This must be a field that persists ACROSS frames, not a local
+    /// variable snapshotted at the top of `show_buttons` within the same
+    /// frame — Press-Key capture mutates `click_btn` inside `logic()`,
+    /// which runs BEFORE `ui()` in the same frame, so a same-frame local
+    /// "before" snapshot taken in `ui()` would already equal "after" and
+    /// never detect the change. A manual dropdown pick mutates `click_btn`
+    /// live inside `ui()` itself, so it happened to work with a same-frame
+    /// snapshot — which is exactly why an earlier version of this feature
+    /// showed the confirmation for dropdown picks but not for captures.
+    pub last_seen_click_btn: ClickButton,
 
     // RNG
     pub rng_thread: ThreadRng,
@@ -125,6 +193,10 @@ impl Default for RustyAutoClickerApp {
             speed_min_str: MOUSE_TWEEN_SPEED_MIN_PX_S.to_string(),
             speed_max_str: MOUSE_TWEEN_SPEED_MAX_PX_S.to_string(),
 
+            random_offset_enabled: false,
+            random_offset_str: DEFAULT_RANDOM_OFFSET_STR.to_owned(),
+            current_interval_ms: 0,
+
             last_now: Instant::now(),
             frame_start: Instant::now(),
 
@@ -142,6 +214,7 @@ impl Default for RustyAutoClickerApp {
             hotkey_window_open: false,
             auto_minimized_for_picker: false,
             last_window_size: [WINDOW_WIDTH, WINDOW_HEIGHT],
+            ui_scale: 1.0,
             last_window_pos: egui::pos2(WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y),
 
             key_pressed_autoclick: false,
@@ -155,6 +228,11 @@ impl Default for RustyAutoClickerApp {
             click_btn: ClickButton::Mouse(Button::Left),
             click_type: ClickType::Single,
             click_position: ClickPosition::Mouse,
+            click_key_capture_error: None,
+            click_key_capture_feedback: None,
+            click_key_capture_feedback_set_at: None,
+            last_keyboard_key: Key::Space,
+            last_seen_click_btn: ClickButton::Mouse(Button::Left),
 
             rng_thread: rng(),
             device_state: DeviceState::new(),
@@ -183,7 +261,18 @@ impl RustyAutoClickerApp {
             // one-time startup restore, not a "resize" in the runtime sense
             // the user cares about, so it's exempt from the
             // "only user/Reset may resize" rule.
+            //
+            // Clamped to at least [`WINDOW_MIN_WIDTH`]/[`WINDOW_MIN_HEIGHT`]
+            // before being applied: a saved size can be corrupted or
+            // degenerate (hand-edited settings.json, a bug in an older
+            // version, etc.), and restoring it verbatim used to be able to
+            // soft-brick the app — shrinking the window down to something
+            // with no usable controls and no way to resize it back up
+            // without manually deleting settings.json. Clamping here means
+            // that can never happen again, regardless of what's on disk.
             if let Some([w, h]) = loaded.window_size {
+                let w = w.max(WINDOW_MIN_WIDTH);
+                let h = h.max(WINDOW_MIN_HEIGHT);
                 app.last_window_size = [w, h];
                 ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(w, h)));
             }
@@ -204,13 +293,13 @@ impl RustyAutoClickerApp {
         // screen resolution, same as the Reset button does, instead of the
         // old hardcoded WINDOW_DEFAULT_X/Y fallback. Still sent before the
         // first frame paints, so there's no flicker on first launch either.
-        if !had_saved_position {
-            if let Some(cmd) = egui::ViewportCommand::center_on_screen(ctx) {
-                if let egui::ViewportCommand::OuterPosition(pos) = cmd {
-                    app.last_window_pos = pos;
-                }
-                ctx.send_viewport_cmd(cmd);
+        if !had_saved_position
+            && let Some(cmd) = egui::ViewportCommand::center_on_screen(ctx)
+        {
+            if let egui::ViewportCommand::OuterPosition(pos) = cmd {
+                app.last_window_pos = pos;
             }
+            ctx.send_viewport_cmd(cmd);
         }
 
         app
@@ -229,10 +318,13 @@ impl RustyAutoClickerApp {
     /// resize the window back to the default size, and move it to the
     /// default position. Persists immediately so the reset survives the next launch.
     ///
-    /// This is one of exactly two places in the whole app allowed to resize
-    /// the main window at runtime (the other being a manual drag by the
-    /// user, which egui/the OS handles directly and never goes through this
-    /// code at all).
+    /// Resizing the main window at runtime now happens in exactly two
+    /// places: this reset, and a manual drag by the user (handled directly
+    /// by egui/the OS, never goes through this code). The layout itself
+    /// reflows to whatever size the window actually is (see
+    /// `gui/sections/*.rs`), so there is no longer a third,
+    /// content-driven auto-resize mechanism fighting for control of the
+    /// window size.
     pub fn reset_to_defaults(&mut self, ctx: &egui::Context) {
         self.hr_str = DEFAULT_HR_STR.to_owned();
         self.min_str = DEFAULT_MIN_STR.to_owned();
@@ -244,15 +336,24 @@ impl RustyAutoClickerApp {
         self.speed_min_str = MOUSE_TWEEN_SPEED_MIN_PX_S.to_string();
         self.speed_max_str = MOUSE_TWEEN_SPEED_MAX_PX_S.to_string();
 
+        self.random_offset_enabled = false;
+        self.random_offset_str = DEFAULT_RANDOM_OFFSET_STR.to_owned();
+
         self.key_autoclick = HOTKEY_AUTOCLICK;
         self.key_open_set_coord = HOTKEY_OPEN_SET_COORD;
         self.key_set_coord = HOTKEY_SET_COORD;
         self.key_hold = HOTKEY_HOLD;
 
         self.click_btn = ClickButton::Mouse(Button::Left);
+        self.last_seen_click_btn = self.click_btn;
         self.click_type = ClickType::Single;
         self.click_position = ClickPosition::Mouse;
         self.app_mode = AppMode::Bot;
+
+        self.last_keyboard_key = Key::Space;
+        self.click_key_capture_error = None;
+        self.click_key_capture_feedback = None;
+        self.click_key_capture_feedback_set_at = None;
 
         // Resize back to the original window size and move it back to the
         // true center of the screen it's currently on. We use egui's own
@@ -293,7 +394,20 @@ impl RustyAutoClickerApp {
     pub fn is_autoclicking(&self) -> bool { matches!(self.mode, InteractionMode::Autoclicking) }
     pub fn is_holding(&self) -> bool { matches!(self.mode, InteractionMode::Holding) }
     pub fn is_setting_coord(&self) -> bool { matches!(self.mode, InteractionMode::SettingCoord) }
+    pub fn is_setting_click_key(&self) -> bool { matches!(self.mode, InteractionMode::SettingClickKey) }
     pub fn is_busy(&self) -> bool {
+        // NOTE: `is_setting_click_key()` is deliberately NOT included here.
+        // Capturing a click key only needs to lock the Mouse/Keyboard radio
+        // (handled directly in `gui/sections/buttons.rs` via
+        // `add_enabled_ui(!self.is_setting_click_key(), ...)`) — it doesn't
+        // need to freeze Click Interval/Amount/Position/Movement Speed too.
+        // An earlier version included it here, which dimmed all of those
+        // for the capture's duration; when the captured key happened to
+        // match what was already selected (no visible dropdown-text
+        // change), that dimming-then-undimming was the ONLY visible thing
+        // that happened, which read as "everything went black with no
+        // feedback." See `click_key_capture_feedback` for the actual fix
+        // (an explicit confirmation message on every successful capture).
         self.is_autoclicking() || self.is_holding() || self.hotkey_window_open || self.is_setting_coord()
     }
     pub fn is_idle(&self) -> bool { matches!(self.mode, InteractionMode::Idle) }
@@ -309,7 +423,7 @@ impl RustyAutoClickerApp {
     pub fn autoclick_button_label(&self) -> String {
         let verb = if self.is_autoclicking() { "STOP" } else { "START" };
         match self.key_autoclick {
-            Some(k) => format!("🖱 {verb} ({k})"),
+            Some(k) => format!("🖱 {verb} ({})", crate::utils::abbreviate_keycode(k)),
             None => format!("🖱 {verb}"),
         }
     }
@@ -317,7 +431,7 @@ impl RustyAutoClickerApp {
     pub fn hold_button_label(&self) -> String {
         let verb = if self.is_holding() { "RELEASE" } else { "HOLD" };
         match self.key_hold {
-            Some(k) => format!("{verb} ({k})"),
+            Some(k) => format!("{verb} ({})", crate::utils::abbreviate_keycode(k)),
             None => verb.to_string(),
         }
     }
@@ -336,6 +450,7 @@ impl RustyAutoClickerApp {
         sanitize_i64_string(&mut self.click_y_str, INPUT_LEN_COORD);
         sanitize_string(&mut self.speed_min_str, INPUT_LEN_TIME);
         sanitize_string(&mut self.speed_max_str, INPUT_LEN_TIME);
+        sanitize_string(&mut self.random_offset_str, INPUT_LEN_TIME);
     }
 
     pub fn parsed_interval_ms(&self) -> u64 {
@@ -354,6 +469,8 @@ impl RustyAutoClickerApp {
     }
 
     pub fn parsed_click_amount(&self) -> u64 { self.click_amount_str.parse().unwrap_or_default() }
+
+    pub fn parsed_random_offset_ms(&self) -> u64 { self.random_offset_str.parse().unwrap_or_default() }
 
     pub fn parsed_click_coord(&self) -> (f64, f64) {
         (
@@ -428,6 +545,25 @@ impl RustyAutoClickerApp {
         self.last_now = Instant::now()
             .checked_sub(Duration::from_millis(negative_click_start_offset))
             .unwrap();
+        self.current_interval_ms = self.roll_next_interval(self.parsed_interval_ms());
+    }
+
+    /// The interval (ms) to actually wait for THIS click cycle: the base
+    /// Click Interval as-is when Random Offset is off (or its field is
+    /// "0"/blank), otherwise the base interval jittered by a fresh random
+    /// amount in `[-offset, +offset]`, floored at 0 so a large offset can
+    /// shrink the wait but never produce a negative one.
+    pub fn roll_next_interval(&mut self, base_interval: u64) -> u64 {
+        if !self.random_offset_enabled {
+            return base_interval;
+        }
+        let offset = self.parsed_random_offset_ms();
+        if offset == 0 {
+            return base_interval;
+        }
+        let offset = offset as i64;
+        let jitter = self.rng_thread.random_range(-offset..=offset);
+        (base_interval as i64 + jitter).max(0) as u64
     }
 
     pub fn start_hold(&mut self) {
@@ -450,6 +586,97 @@ impl RustyAutoClickerApp {
             release_button(button);
         }
         self.mode = InteractionMode::Idle;
+    }
+
+    // -----------------------------------------------------------------------
+    // Click-key capture ("press the key you want the autoclicker to use")
+    // -----------------------------------------------------------------------
+
+    /// Enter click-key capture mode. Called from the "Press Key" button in
+    /// `gui/sections/buttons.rs`. Clears any stale error from a previous
+    /// capture attempt.
+    pub fn enter_click_key_capture(&mut self) {
+        if !self.is_idle() {
+            return;
+        }
+        self.click_key_capture_error = None;
+        self.click_key_capture_feedback = None;
+        self.mode = InteractionMode::SettingClickKey;
+    }
+
+    /// Cancel click-key capture without changing `click_btn`.
+    pub fn cancel_click_key_capture(&mut self) {
+        self.click_key_capture_error = None;
+        self.mode = InteractionMode::Idle;
+    }
+
+    /// Auto-clear the "Set to X" feedback message after
+    /// `CLICK_KEY_FEEDBACK_TIMEOUT_SECS`. Called once per frame from
+    /// `logic()`. Deliberately does NOT clear `click_key_capture_error` —
+    /// an unresolved conflict/unsupported-key error should stay visible
+    /// until the user acts on it (switches to Mouse, picks another key, or
+    /// cancels), not silently disappear on a timer.
+    pub fn tick_click_key_feedback_timeout(&mut self) {
+        let expired = self
+            .click_key_capture_feedback_set_at
+            .is_some_and(|set_at| set_at.elapsed() >= Duration::from_secs(CLICK_KEY_FEEDBACK_TIMEOUT_SECS));
+        if expired {
+            self.click_key_capture_feedback = None;
+            self.click_key_capture_feedback_set_at = None;
+        }
+    }
+
+    /// Look for a key that was pressed last frame and is no longer pressed
+    /// this frame (same released-edge pattern as `capture_key` in
+    /// `gui/mod.rs`), and try to use it as the click button.
+    ///
+    /// Rejects (sets `click_key_capture_error`, stays in capture mode so the
+    /// user can try again) when:
+    ///   - the key is already bound to one of the global hotkeys
+    ///     (start/stop, open-coord-picker, confirm-coord, hold), since a
+    ///     shared key would make it impossible to tell which action fired,
+    ///   - the key has no `rdev::Key` counterpart in the dropdown, in which
+    ///     case only the manual dropdown can select it.
+    pub fn capture_click_key(&mut self, last_keys: Option<&[Keycode]>, keys: &[Keycode]) {
+        let Some(last_keys) = last_keys else { return };
+        for pressed_key in last_keys {
+            if keys.contains(pressed_key) {
+                continue;
+            }
+            let pressed_key = *pressed_key;
+
+            let conflict = [
+                (self.key_autoclick, "Start/Stop"),
+                (self.key_open_set_coord, "Set Coords"),
+                (self.key_set_coord, "Confirm Coords"),
+                (self.key_hold, "Click & Hold"),
+            ]
+            .into_iter()
+            .find_map(|(hotkey, label)| (hotkey == Some(pressed_key)).then_some(label));
+
+            if let Some(label) = conflict {
+                self.click_key_capture_error = Some(format!(
+                    "\"{}\" is already the \"{label}\" hotkey — pick a different key",
+                    crate::utils::abbreviate_keycode(pressed_key)
+                ));
+                continue;
+            }
+
+            match crate::utils::keycode_to_rdev_key(pressed_key) {
+                Some(key) => {
+                    self.click_btn = ClickButton::Key(key);
+                    self.click_key_capture_error = None;
+                    self.mode = InteractionMode::Idle;
+                }
+                None => {
+                    self.click_key_capture_error = Some(format!(
+                        "\"{}\" isn't supported for auto-capture — pick it from the dropdown instead",
+                        crate::utils::abbreviate_keycode(pressed_key)
+                    ));
+                }
+            }
+            break;
+        }
     }
 }
 

--- a/src/defines.rs
+++ b/src/defines.rs
@@ -8,9 +8,14 @@ pub const APP_ICON: &[u8] = include_bytes!("../assets/icon-64x64.ico");
 pub const FONT_SIZE: f32 = 12.0;
 pub const FONT_FAMILY: FontFamily = FontFamily::Monospace;
 
-// dimensions of main window
-pub const WINDOW_WIDTH: f32 = 550.0;
-pub const WINDOW_HEIGHT: f32 = 341.0;
+// Default window size (logical pixels) — the original GUI dimensions
+pub const WINDOW_WIDTH: f32 = 580.0;
+pub const WINDOW_HEIGHT: f32 = 340.0;
+
+// Default window position — used by Reset and as the first-run fallback.
+// Adjust these to wherever you want the window to appear on a fresh install.
+pub const WINDOW_DEFAULT_X: f32 = 100.0;
+pub const WINDOW_DEFAULT_Y: f32 = 100.0;
 
 // ranges for click durations
 pub const DURATION_CLICK_MIN: u64 = 20;
@@ -19,24 +24,24 @@ pub const DURATION_DOUBLE_CLICK_MIN: u64 = 30;
 pub const DURATION_DOUBLE_CLICK_MAX: u64 = 60;
 
 // humanlike mouse tweening
-pub const MOUSE_TWEEN_STEP_PX: f64 = 10.0; // approx. path distance per step
-pub const MOUSE_TWEEN_MIN_STEPS: u64 = 4; // floor so short moves still glide
-pub const MOUSE_TWEEN_CURVE_RATIO_MIN: f64 = 0.05; // curve bow, fraction of distance
+pub const MOUSE_TWEEN_STEP_PX: f64 = 10.0;
+pub const MOUSE_TWEEN_MIN_STEPS: u64 = 4;
+pub const MOUSE_TWEEN_CURVE_RATIO_MIN: f64 = 0.05;
 pub const MOUSE_TWEEN_CURVE_RATIO_MAX: f64 = 0.18;
-pub const MOUSE_TWEEN_CURVE_MAX_PX: f64 = 120.0; // bow cap for long moves
-pub const MOUSE_TWEEN_TREMOR_PX: f64 = 1.5; // hand tremor amplitude
-pub const MOUSE_TWEEN_TREMOR_DIST_THRESHOLD_PX: f64 = 480.0; // far moves allow more mid-tween tremors
-pub const MOUSE_TWEEN_TREMOR_MAX_NEAR: u64 = 1; // max mid-tween tremors below threshold
-pub const MOUSE_TWEEN_TREMOR_MAX_FAR: u64 = 2; // max mid-tween tremors at/above threshold
-pub const MOUSE_TWEEN_DELAY_JITTER_FRAC: f64 = 0.5; // per-step delay jitter: ±50%
-pub const MOUSE_TWEEN_SPEED_MIN_PX_S: f64 = 1500.0; // default glide speed range
+pub const MOUSE_TWEEN_CURVE_MAX_PX: f64 = 120.0;
+pub const MOUSE_TWEEN_TREMOR_PX: f64 = 1.5;
+pub const MOUSE_TWEEN_TREMOR_DIST_THRESHOLD_PX: f64 = 480.0;
+pub const MOUSE_TWEEN_TREMOR_MAX_NEAR: u64 = 1;
+pub const MOUSE_TWEEN_TREMOR_MAX_FAR: u64 = 2;
+pub const MOUSE_TWEEN_DELAY_JITTER_FRAC: f64 = 0.5;
+pub const MOUSE_TWEEN_SPEED_MIN_PX_S: f64 = 1500.0;
 pub const MOUSE_TWEEN_SPEED_MAX_PX_S: f64 = 4000.0;
 
-// Default input values
+// Default input values (click coords, not window position)
 pub const DEFAULT_HR_STR: &str = "0";
 pub const DEFAULT_MIN_STR: &str = "0";
 pub const DEFAULT_SEC_STR: &str = "0";
-pub const DEFAULT_MS_STR: &str = "100";
+pub const DEFAULT_MS_STR: &str = "200";
 pub const DEFAULT_CLICK_AMOUNT_STR: &str = "0";
 pub const DEFAULT_CLICK_X_STR: &str = "0";
 pub const DEFAULT_CLICK_Y_STR: &str = "0";
@@ -47,5 +52,6 @@ pub const INPUT_LEN_COORD: usize = 7;
 
 // Hotkeys
 pub const HOTKEY_AUTOCLICK: Option<Keycode> = Some(Keycode::F6);
+pub const HOTKEY_OPEN_SET_COORD: Option<Keycode> = Some(Keycode::F10);
 pub const HOTKEY_SET_COORD: Option<Keycode> = Some(Keycode::Escape);
 pub const HOTKEY_HOLD: Option<Keycode> = Some(Keycode::F7);

--- a/src/defines.rs
+++ b/src/defines.rs
@@ -8,9 +8,71 @@ pub const APP_ICON: &[u8] = include_bytes!("../assets/icon-64x64.ico");
 pub const FONT_SIZE: f32 = 12.0;
 pub const FONT_FAMILY: FontFamily = FontFamily::Monospace;
 
-// Default window size (logical pixels) — the original GUI dimensions
+// Default window size (logical pixels) — the original GUI dimensions.
+// This stays a fixed constant: it's what Reset restores and what a
+// fresh install starts at. It is NOT what the responsive layout computes
+// or targets — the layout scales to whatever size the window actually is,
+// between WINDOW_MIN_WIDTH/HEIGHT below and however large the user grows it.
+//
+// WINDOW_HEIGHT was bumped from the original 340 to fit the Random Offset
+// row added alongside Click Interval, then bumped again (380 -> 374) for a
+// SMALL, EQUAL amount of breathing room both ABOVE AND BELOW the Start/Hold
+// buttons (see `show_autoclicker` in `gui/sections/mod.rs`) — just enough
+// that row doesn't sit flush against the separator above it or the bottom
+// bar below. `CentralPanel`'s and the bottom panel's own fixed (unscaled)
+// frame margins are zeroed out on the sides that face the buttons (see
+// those frames in `gui/mod.rs::ui()` and `show_bottombar`), so
+// `show_autoclicker`'s `gap` is the ONLY source of that spacing on both
+// sides — otherwise the fixed frame margins stacked on top of it and made
+// the bottom gap visibly bigger than the top one. At 1:1 scale the content
+// column needs ~316px and the topbar+bottombar+panel margins eat another
+// ~56px regardless of window size, so anything under ~372 no longer had
+// Default window height (logical pixels). Chosen so the default view
+// renders at (approximately) `ui_scale == 1.0` in `gui/mod.rs` — i.e.
+// pixel-parity with the original fixed-size design — rather than the
+// content needing to shrink below scale 1.0 just to fit inside a shorter
+// default window. Leaves a small, roughly symmetric gap above and below
+// the Start/Hold button row at the default size.
 pub const WINDOW_WIDTH: f32 = 580.0;
-pub const WINDOW_HEIGHT: f32 = 340.0;
+pub const WINDOW_HEIGHT: f32 = 372.0;
+
+// Minimum resizable window size (logical pixels), enforced both by
+// `ViewportBuilder::with_min_inner_size` (so the OS/eframe refuses to let
+// the user drag it any smaller) and by clamping any saved/loaded window
+// size on startup (see `app.rs::new()`) so a corrupted or degenerate saved
+// size can never soft-brick the app the way it used to. Chosen small enough
+// to stay flexible while still keeping the title bar controls plus one full
+// row of the most important controls (Click Interval) usable and unclipped.
+//
+// 465 (not 420) specifically: below ~452, `ui_scale` is still WIDTH-bound
+// (`w / WINDOW_WIDTH` is the smaller ratio), and in that regime the topbar's
+// required content width scales up in exact lockstep with the window width
+// — so growing the width alone never gained any slack, and "App Mode: Bot
+// Human" stayed clipped no matter how close to 452 the width got. Past
+// ~452, HEIGHT (`WINDOW_MIN_HEIGHT`) becomes the binding ratio instead, so
+// `ui_scale` stops climbing and extra width turns into real usable slack.
+// 465 sits a bit past that crossover so the full "Human" label (including
+// its final "n") reliably clears the window edge instead of clipping.
+pub const WINDOW_MIN_WIDTH: f32 = 465.0;
+// Minimum window height, coupled to `WINDOW_MIN_WIDTH` above through
+// `ui_scale`'s `min(width_ratio, height_ratio)` in `gui/mod.rs` — raising
+// one can shift which axis is binding and change how much vertical room
+// content actually needs at the minimum, so the two aren't independent.
+// If `WINDOW_MIN_WIDTH` changes, this should be re-checked rather than
+// assumed to still be correct. Leaves a small amount of slack below the
+// Start/Hold button row at the enforced minimum size, matching the same
+// gap the default view has.
+pub const WINDOW_MIN_HEIGHT: f32 = 307.0;
+
+// Uniform UI scale bounds. The whole UI — font size, spacing, padding,
+// button/field sizes — scales together as one unit by the SAME factor,
+// derived each frame from how the current window size compares to the
+// default WINDOW_WIDTH/WINDOW_HEIGHT (see `ui_scale` in `app.rs` and its
+// computation in `gui/mod.rs::ui()`). The floor keeps text legible at the
+// enforced minimum window size instead of shrinking indefinitely; the
+// ceiling stops it from growing unreasonably large on a very big window.
+pub const UI_SCALE_MIN: f32 = 0.7;
+pub const UI_SCALE_MAX: f32 = 1.5;
 
 // Default window position — used by Reset and as the first-run fallback.
 // Adjust these to wherever you want the window to appear on a fresh install.
@@ -45,6 +107,9 @@ pub const DEFAULT_MS_STR: &str = "200";
 pub const DEFAULT_CLICK_AMOUNT_STR: &str = "0";
 pub const DEFAULT_CLICK_X_STR: &str = "0";
 pub const DEFAULT_CLICK_Y_STR: &str = "0";
+/// Default +/- range (ms) shown in the Random Offset field. Only actually
+/// applied to the click interval while `random_offset_enabled` is on.
+pub const DEFAULT_RANDOM_OFFSET_STR: &str = "40";
 
 // Maximum lengths for sanitized numeric inputs
 pub const INPUT_LEN_TIME: usize = 5;
@@ -55,3 +120,7 @@ pub const HOTKEY_AUTOCLICK: Option<Keycode> = Some(Keycode::F6);
 pub const HOTKEY_OPEN_SET_COORD: Option<Keycode> = Some(Keycode::F10);
 pub const HOTKEY_SET_COORD: Option<Keycode> = Some(Keycode::Escape);
 pub const HOTKEY_HOLD: Option<Keycode> = Some(Keycode::F7);
+
+/// How long the green "Set to X" / red conflict-error message under the
+/// Buttons row stays visible before auto-clearing.
+pub const CLICK_KEY_FEEDBACK_TIMEOUT_SECS: u64 = 5;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use device_query::{DeviceQuery, DeviceState, Keycode, MouseState};
+use device_query::{DeviceQuery, Keycode, MouseState};
 use eframe::egui;
 
 use crate::{
@@ -13,34 +13,26 @@ mod sections;
 mod windows;
 
 impl RustyAutoClickerApp {
-    /// Poll the current mouse and keyboard state, caching the mouse snapshot so
-    /// `ui` can display it while all device polling stays in `logic`.
+    /// Poll mouse and keyboard from the cached `DeviceState` (created once in
+    /// `Default::default()`, never reconstructed). This avoids the overhead of
+    /// re-initializing the OS device handle on every frame.
     fn poll_devices(&mut self) -> (MouseState, Vec<Keycode>) {
-        let device_state = DeviceState::new();
-        let mouse = device_state.get_mouse();
-        let keys = device_state.get_keys();
+        let mouse = self.device_state.get_mouse();
+        let keys = self.device_state.get_keys();
         self.mouse = mouse.clone();
         (mouse, keys)
     }
 
-    /// Close the hotkeys window once Escape is pressed and then released, but
-    /// only while the app is idle.
     fn handle_hotkey_window_escape(&mut self, keys: &[Keycode]) {
-        if !self.hotkey_window_open {
-            return;
-        }
+        if !self.hotkey_window_open { return; }
         if keys.contains(&Keycode::Escape) {
             self.key_pressed_esc = true;
         } else if self.key_pressed_esc {
-            // Close only if app is not busy
-            if self.is_idle() {
-                self.hotkey_window_open = false;
-            }
+            if self.is_idle() { self.hotkey_window_open = false; }
             self.key_pressed_esc = false;
         }
     }
 
-    /// Toggle autoclicking when the configured hotkey is pressed and released.
     fn handle_autoclick_toggle(&mut self, keys: &[Keycode], interval: u64) {
         if self.key_autoclick.is_some() && keys.contains(&self.key_autoclick.unwrap()) {
             self.key_pressed_autoclick = true;
@@ -49,14 +41,11 @@ impl RustyAutoClickerApp {
             if self.is_autoclicking() {
                 self.mode = InteractionMode::Idle;
             } else if self.is_idle() && !self.hotkey_window_open {
-                // Start autoclick, first click is instantaneous
                 self.start_autoclick(interval);
             }
         }
     }
 
-    /// Toggle click-and-hold when the configured hotkey is pressed and released:
-    /// press the selected button down, then release it on the next press.
     fn handle_hold_toggle(&mut self, keys: &[Keycode]) {
         if self.key_hold.is_some() && keys.contains(&self.key_hold.unwrap()) {
             self.key_pressed_hold = true;
@@ -70,9 +59,26 @@ impl RustyAutoClickerApp {
         }
     }
 
-    /// Fire a click if the interval has elapsed, advancing the counter and
-    /// stopping when the requested amount is reached. Returns `true` if a click
-    /// was dispatched this pass.
+    /// Handle the "open coordinate picker" hotkey (F10).
+    ///
+    /// If the main window is visible, this minimizes it (so only the
+    /// picker is on screen) via `enter_coordinate_setting`; if it's already
+    /// minimized, it's left untouched. Entering the mode is a plain,
+    /// idempotent state transition guarded by `is_idle()`, so holding/
+    /// spamming F10 can never double-fire, crash, or fight with itself.
+    fn handle_open_set_coord_toggle(&mut self, ctx: &egui::Context, keys: &[Keycode]) {
+        if self.key_open_set_coord.is_some()
+            && keys.contains(&self.key_open_set_coord.unwrap())
+        {
+            self.key_pressed_open_set_coord = true;
+        } else if self.key_pressed_open_set_coord {
+            self.key_pressed_open_set_coord = false;
+            if self.is_idle() && !self.hotkey_window_open {
+                self.enter_coordinate_setting(ctx);
+            }
+        }
+    }
+
     fn dispatch_click(
         &mut self,
         now: Instant,
@@ -90,10 +96,7 @@ impl RustyAutoClickerApp {
         }
 
         #[cfg(debug_assertions)]
-        println!(
-            "{:?} {:?} Click: {since_last:?}",
-            self.click_type, self.click_btn
-        );
+        println!("{:?} {:?} Click: {since_last:?}", self.click_type, self.click_btn);
         self.last_now = Instant::now();
 
         autoclick(
@@ -109,7 +112,6 @@ impl RustyAutoClickerApp {
             self.rng_thread.clone(),
         );
 
-        // Increment click counter and stop autoclicking if completed
         self.click_counter += 1u64;
         if click_amount != 0u64 && self.click_counter >= click_amount {
             self.mode = InteractionMode::Idle;
@@ -117,18 +119,13 @@ impl RustyAutoClickerApp {
         true
     }
 
-    /// Record the next released key into `target_key`, clearing `target_flag`.
-    /// An associated function so the two disjoint `&mut` fields can be borrowed
-    /// from `self` at the call site.
     fn capture_key(
         target_key: &mut Option<Keycode>,
         mode: &mut InteractionMode,
         last_keys: Option<&[Keycode]>,
         keys: &[Keycode],
     ) {
-        let Some(last_keys) = last_keys else {
-            return;
-        };
+        let Some(last_keys) = last_keys else { return };
         for pressed_key in last_keys {
             if !keys.contains(pressed_key) {
                 *target_key = Some(*pressed_key);
@@ -138,194 +135,145 @@ impl RustyAutoClickerApp {
         }
     }
 
-    /// Track the cursor while setting coordinates, exiting on a left-click or the
-    /// configured confirm key.
-    fn update_coordinate_setting(
-        &mut self,
-        ctx: &egui::Context,
-        mouse: &MouseState,
-        keys: &[Keycode],
-    ) {
-        self.click_x_str = mouse.coords.0.to_string();
-        self.click_y_str = mouse.coords.1.to_string();
-
-        // Stop if mouse left click
-        if mouse.button_pressed[1]
-            || (self.key_set_coord.is_some() && keys.contains(&self.key_set_coord.unwrap()))
-        {
-            self.exit_coordinate_setting(ctx);
-        }
-    }
-
-    /// Force the hotkeys window open while either hotkey is unset.
     fn ensure_hotkey_window(&mut self) {
         if !self.hotkey_window_open
             && (self.key_autoclick.is_none()
+                || self.key_open_set_coord.is_none()
                 || self.key_set_coord.is_none()
                 || self.key_hold.is_none())
         {
             self.hotkey_window_open = true;
         }
     }
+
+    /// Track window size and position every frame so `Drop` can persist the
+    /// final geometry on close.
+    ///
+    /// **Guarded to the ROOT viewport only.** `show_coord_picker_viewport`
+    /// (called just above this, at line ~215) registers/drives the picker's
+    /// deferred viewport via the SAME shared `egui::Context`. Under rapid
+    /// F10 + confirm spam, egui's internal "current viewport" bookkeeping
+    /// can transiently still be set to the picker's ID at the moment this
+    /// function runs afterward in the same `logic()` call — in which case
+    /// `ctx.input(|i| i.viewport())` would report the picker's tiny
+    /// inner_rect/outer_rect instead of the main window's, and we'd persist
+    /// THAT as the main window's saved geometry. That is the exact
+    /// mechanism behind "main window shrinks to picker size" under rapid
+    /// spam. Explicitly checking `ctx.viewport_id() == ViewportId::ROOT`
+    /// makes it structurally impossible to record anything but the real
+    /// main-window geometry here, regardless of timing.
+    fn track_window_geometry(&mut self, ctx: &egui::Context) {
+        if ctx.viewport_id() != egui::ViewportId::ROOT {
+            return;
+        }
+        ctx.input(|i| {
+            let vp = i.viewport();
+            if let Some(rect) = vp.inner_rect {
+                self.last_window_size = [rect.width(), rect.height()];
+            }
+            if let Some(rect) = vp.outer_rect {
+                self.last_window_pos = rect.min;
+            }
+        });
+    }
 }
 
 impl eframe::App for RustyAutoClickerApp {
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
-        egui::Rgba::TRANSPARENT.to_array() // Make sure we don't paint anything behind the rounded corners
+        egui::Rgba::TRANSPARENT.to_array()
     }
 
-    /// Runs every pass, including while the window is hidden/minimized, as long as a repaint was requested.
     fn logic(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Print time to between start of old and new frames
         #[cfg(debug_assertions)]
         println!(
             "Frame delta: {:?}",
-            Instant::now()
-                .checked_duration_since(self.frame_start)
-                .unwrap()
+            Instant::now().checked_duration_since(self.frame_start).unwrap()
         );
-
         self.frame_start = Instant::now();
 
-        // Poll input devices (mouse snapshot is cached for `ui` to display)
         let (mouse, keys) = self.poll_devices();
 
-        // Sanitize the numeric input strings, then parse the values needed this pass
         self.sanitize_inputs();
-        let interval = self.parsed_interval_ms();
+        let interval    = self.parsed_interval_ms();
         let speed_range = self.parsed_speed_range();
         let click_amount = self.parsed_click_amount();
         let click_coord = self.parsed_click_coord();
 
         self.handle_hotkey_window_escape(&keys);
 
-        // Sample the clock once, before the toggle, and reuse it for the click timing
         let update_now = Instant::now();
         self.handle_autoclick_toggle(&keys, interval);
         self.handle_hold_toggle(&keys);
+        self.handle_open_set_coord_toggle(ctx, &keys);
 
-        // At most one of these runs per pass (mutually exclusive)
-        if !self.dispatch_click(
-            update_now,
-            interval,
-            click_amount,
-            click_coord,
-            speed_range,
-            mouse.coords,
-        ) {
-            if matches!(self.mode, InteractionMode::SettingAutoclickKey)
-                && self.keys_pressed.is_some()
-            {
-                Self::capture_key(
-                    &mut self.key_autoclick,
-                    &mut self.mode,
-                    self.keys_pressed.as_deref(),
-                    &keys,
-                );
-            } else if matches!(self.mode, InteractionMode::SettingSetCoordKey)
-                && self.keys_pressed.is_some()
-            {
-                Self::capture_key(
-                    &mut self.key_set_coord,
-                    &mut self.mode,
-                    self.keys_pressed.as_deref(),
-                    &keys,
-                );
-            } else if matches!(self.mode, InteractionMode::SettingHoldKey)
-                && self.keys_pressed.is_some()
-            {
-                Self::capture_key(
-                    &mut self.key_hold,
-                    &mut self.mode,
-                    self.keys_pressed.as_deref(),
-                    &keys,
-                );
-            } else if matches!(self.mode, InteractionMode::SettingCoord) {
-                self.update_coordinate_setting(ctx, &mouse, &keys);
+        if !self.dispatch_click(update_now, interval, click_amount, click_coord, speed_range, mouse.coords) {
+            if matches!(self.mode, InteractionMode::SettingAutoclickKey) && self.keys_pressed.is_some() {
+                Self::capture_key(&mut self.key_autoclick, &mut self.mode, self.keys_pressed.as_deref(), &keys);
+            } else if matches!(self.mode, InteractionMode::SettingOpenCoordKey) && self.keys_pressed.is_some() {
+                Self::capture_key(&mut self.key_open_set_coord, &mut self.mode, self.keys_pressed.as_deref(), &keys);
+            } else if matches!(self.mode, InteractionMode::SettingSetCoordKey) && self.keys_pressed.is_some() {
+                Self::capture_key(&mut self.key_set_coord, &mut self.mode, self.keys_pressed.as_deref(), &keys);
+            } else if matches!(self.mode, InteractionMode::SettingHoldKey) && self.keys_pressed.is_some() {
+                Self::capture_key(&mut self.key_hold, &mut self.mode, self.keys_pressed.as_deref(), &keys);
             }
         }
 
-        // Save state of pressed keys
-        self.keys_pressed = Some(keys.clone());
+        // Drive the coordinate-picker viewport from `logic()`, NOT `ui()`.
+        // `ui()` is skipped by the OS while the main window is minimized,
+        // but `logic()` always runs — this is what lets F10 keep working
+        // (opening, following the cursor, and confirming) even while the
+        // main window stays minimized the entire time, with no restore.
+        if self.is_setting_coord() {
+            self.show_coord_picker_viewport(ctx, &mouse, &keys);
+        }
 
+        self.keys_pressed = Some(keys);
         self.ensure_hotkey_window();
+        self.track_window_geometry(ctx);
 
-        // Keep updating frame
+        // Always request a repaint so hotkeys are polled every frame.
+        // egui already throttles to ~60 fps so this does not cause excessive
+        // CPU usage — but it ensures F6/F7/F10 are never delayed by a sleep.
         ctx.request_repaint();
 
-        // Print time to process frame
         #[cfg(debug_assertions)]
         println!(
             "Frame time: {:?}",
-            Instant::now()
-                .checked_duration_since(self.frame_start)
-                .unwrap()
+            Instant::now().checked_duration_since(self.frame_start).unwrap()
         );
     }
 
-    /// Called each time the UI needs repainting, but only while the window is visible.
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        // Cheap `Arc`-handle clone of the context so helpers/windows can use it without
-        // conflicting with the `&mut ui` borrows taken by `show_inside`.
         let ctx = ui.ctx().clone();
 
-        if matches!(self.mode, InteractionMode::SettingCoord) {
-            egui::Panel::top("top_panel").show_inside(ui, |ui| {
-                egui::MenuBar::new().ui(ui, |ui| {
-                    ui.horizontal_wrapped(|ui| {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                            self.disable_if_busy(ui);
-                            ui.add(
-                                egui::TextEdit::singleline(&mut self.click_y_str)
-                                    .desired_width(50.0f32)
-                                    .hint_text("0"),
-                            );
-                            ui.label("Y");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut self.click_x_str)
-                                    .desired_width(50.0f32)
-                                    .hint_text("0"),
-                            );
-                            ui.label("X");
-                            ui.separator();
-                            ui.label(format!(
-                                " Set with \"{:}\" / \"L Click\"",
-                                self.key_set_coord.unwrap()
-                            ));
-                        });
-                    });
-                })
-            });
-            Self::follow_cursor(self, &ctx);
-        } else {
-            // GUI
-            // Top and bottom panels first so the central panel fills the remaining space
-            self.show_topbar(ui);
-            self.show_bottombar(ui);
+        // The main window is ALWAYS rendered at its normal size — the
+        // coordinate picker never replaces or resizes it. While picking
+        // (`is_setting_coord()`), the main UI is simply disabled via
+        // `is_busy()`/`disable_if_busy()`, exactly like autoclicking or
+        // holding disable it.
+        self.show_topbar(ui);
+        self.show_bottombar(ui);
 
-            let click_amount = self.parsed_click_amount();
+        let click_amount = self.parsed_click_amount();
 
-            egui::CentralPanel::default().show_inside(ui, |ui| {
-                // The central panel the region left after adding TopPanel's and SidePanel's
-                self.show_click_interval(ui);
-                ui.separator();
-                self.show_movement_speed(ui);
-                ui.separator();
-                self.show_buttons(ui);
-                ui.separator();
-                self.show_click_type(ui);
-                ui.separator();
-                self.show_click_amount(ui, click_amount);
-                ui.separator();
-                self.show_click_position(ui, &ctx);
-                ui.separator();
-                self.show_infos(ui, &self.mouse, self.keys_pressed.as_deref().unwrap_or(&[]));
-                ui.separator();
-                self.show_autoclicker(ui);
-            });
-        }
+        egui::CentralPanel::default().show_inside(ui, |ui| {
+            self.show_click_interval(ui);
+            ui.separator();
+            self.show_movement_speed(ui);
+            ui.separator();
+            self.show_buttons(ui);
+            ui.separator();
+            self.show_click_type(ui);
+            ui.separator();
+            self.show_click_amount(ui, click_amount);
+            ui.separator();
+            self.show_click_position(ui);
+            ui.separator();
+            self.show_infos(ui, &self.mouse, self.keys_pressed.as_deref().unwrap_or(&[]));
+            ui.separator();
+            self.show_autoclicker(ui);
+        });
 
-        // Hotkeys window
         if self.hotkey_window_open {
             self.show_hotkeys_window(&ctx);
         }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,10 +1,11 @@
 use std::time::{Duration, Instant};
 
 use device_query::{DeviceQuery, Keycode, MouseState};
-use eframe::egui;
+use eframe::{egui, epaint::FontId};
 
 use crate::{
     RustyAutoClickerApp,
+    defines::{FONT_FAMILY, FONT_SIZE, UI_SCALE_MAX, UI_SCALE_MIN, WINDOW_HEIGHT, WINDOW_WIDTH},
     types::{ClickInfo, InteractionMode},
     utils::autoclick,
 };
@@ -33,29 +34,43 @@ impl RustyAutoClickerApp {
         }
     }
 
+    /// Fires the toggle on the PRESS edge (not release). This needs only
+    /// ONE poll to land — the one that happens to catch the key already
+    /// down — instead of needing a poll to catch it going down AND a later
+    /// poll to catch it coming back up. `device_query` polls key state
+    /// rather than receiving true OS key-down/key-up events, and the poll
+    /// rate can drop noticeably while the window is minimized (Windows can
+    /// throttle background windows' event loops, which this app's own
+    /// `logic()`/`ui()` split can't fully escape since both still share
+    /// the same underlying event-loop wakeup) — so halving how many polls
+    /// a single tap needs to register meaningfully cuts the miss rate.
     fn handle_autoclick_toggle(&mut self, keys: &[Keycode], interval: u64) {
-        if self.key_autoclick.is_some() && keys.contains(&self.key_autoclick.unwrap()) {
+        let is_pressed = self.key_autoclick.is_some() && keys.contains(&self.key_autoclick.unwrap());
+        if is_pressed && !self.key_pressed_autoclick {
             self.key_pressed_autoclick = true;
-        } else if self.key_pressed_autoclick {
-            self.key_pressed_autoclick = false;
             if self.is_autoclicking() {
                 self.mode = InteractionMode::Idle;
             } else if self.is_idle() && !self.hotkey_window_open {
                 self.start_autoclick(interval);
             }
+        } else if !is_pressed {
+            self.key_pressed_autoclick = false;
         }
     }
 
+    /// Same press-edge fix as `handle_autoclick_toggle` above, for the same
+    /// reason — see that function's doc comment.
     fn handle_hold_toggle(&mut self, keys: &[Keycode]) {
-        if self.key_hold.is_some() && keys.contains(&self.key_hold.unwrap()) {
+        let is_pressed = self.key_hold.is_some() && keys.contains(&self.key_hold.unwrap());
+        if is_pressed && !self.key_pressed_hold {
             self.key_pressed_hold = true;
-        } else if self.key_pressed_hold {
-            self.key_pressed_hold = false;
             if self.is_holding() {
                 self.stop_hold();
             } else if self.is_idle() && !self.hotkey_window_open {
                 self.start_hold();
             }
+        } else if !is_pressed {
+            self.key_pressed_hold = false;
         }
     }
 
@@ -91,7 +106,11 @@ impl RustyAutoClickerApp {
         let since_last = now
             .checked_duration_since(self.last_now)
             .unwrap_or(Duration::ZERO);
-        if !self.is_autoclicking() || (since_last.as_millis() as u64) < interval {
+        // Gate on `current_interval_ms`, not the raw base `interval` — see
+        // that field's doc comment in `app.rs`. It's the base interval,
+        // possibly jittered by Random Offset, rolled fresh once per cycle
+        // rather than re-sampled every frame.
+        if !self.is_autoclicking() || (since_last.as_millis() as u64) < self.current_interval_ms {
             return false;
         }
 
@@ -115,6 +134,12 @@ impl RustyAutoClickerApp {
         self.click_counter += 1u64;
         if click_amount != 0u64 && self.click_counter >= click_amount {
             self.mode = InteractionMode::Idle;
+        } else {
+            // Roll the next cycle's (possibly jittered) interval now, off
+            // the latest live base `interval`, so Random Offset re-rolls a
+            // fresh value every click rather than reusing one draw for the
+            // whole session.
+            self.current_interval_ms = self.roll_next_interval(interval);
         }
         true
     }
@@ -176,6 +201,56 @@ impl RustyAutoClickerApp {
             }
         });
     }
+
+    /// Recompute `ui_scale` from the current window size and apply it
+    /// globally: font size (via `override_font_id`, the single knob that
+    /// controls every widget's text since `app.rs::new()` set it once at
+    /// startup) and `egui::Style::spacing` (padding, control sizes, gaps).
+    /// This is what makes text, buttons, and spacing all shrink or grow
+    /// together as ONE unit as the window is resized, rather than only
+    /// the whitespace between them compressing while text/controls stay a
+    /// fixed size (which is what clipped text and still needed a
+    /// scrollbar at the enforced minimum in an earlier version of this).
+    ///
+    /// `egui::widgets::Separator`'s own thickness isn't part of `Style`
+    /// (it's a hardcoded constant inside egui itself), so section code
+    /// that wants a separator to also scale needs to pass
+    /// `.spacing(6.0 * self.ui_scale)` explicitly rather than using the
+    /// bare `ui.separator()` shorthand — see `gui/mod.rs::ui()`'s content
+    /// list below.
+    fn update_ui_scale(&mut self, ctx: &egui::Context) {
+        // Simple ratio against the default size on both axes. This only
+        // lands at (approximately) 1.0 — i.e. pixel-parity with the
+        // original, pre-scaling design — at the actual default window
+        // size because WINDOW_HEIGHT itself was chosen (see its doc
+        // comment in `defines.rs`) to be tall enough for this content at
+        // 1:1 scale; without that, a plain size ratio would have silently
+        // scaled everything down below 1.0 even at the "normal" size to
+        // compensate for content that didn't actually fit.
+        let [w, h] = self.last_window_size;
+        self.ui_scale = ((w / WINDOW_WIDTH).min(h / WINDOW_HEIGHT))
+            .clamp(UI_SCALE_MIN, UI_SCALE_MAX);
+        let scale = self.ui_scale;
+
+        ctx.global_style_mut(|style| {
+            style.override_font_id =
+                Some(FontId { size: (FONT_SIZE * scale).max(1.0), family: FONT_FAMILY });
+
+            // `egui::style::Spacing::default()` as the fixed baseline that
+            // gets scaled — NOT the current live `style.spacing` — so this
+            // is idempotent frame to frame instead of compounding.
+            let base = egui::style::Spacing::default();
+            style.spacing.item_spacing = base.item_spacing * scale;
+            style.spacing.button_padding = base.button_padding * scale;
+            style.spacing.interact_size = base.interact_size * scale;
+            style.spacing.icon_width = base.icon_width * scale;
+            style.spacing.icon_width_inner = base.icon_width_inner * scale;
+            style.spacing.icon_spacing = base.icon_spacing * scale;
+            style.spacing.combo_width = base.combo_width * scale;
+            style.spacing.text_edit_width = base.text_edit_width * scale;
+            style.spacing.indent = base.indent * scale;
+        });
+    }
 }
 
 impl eframe::App for RustyAutoClickerApp {
@@ -215,6 +290,12 @@ impl eframe::App for RustyAutoClickerApp {
                 Self::capture_key(&mut self.key_set_coord, &mut self.mode, self.keys_pressed.as_deref(), &keys);
             } else if matches!(self.mode, InteractionMode::SettingHoldKey) && self.keys_pressed.is_some() {
                 Self::capture_key(&mut self.key_hold, &mut self.mode, self.keys_pressed.as_deref(), &keys);
+            } else if matches!(self.mode, InteractionMode::SettingClickKey) {
+                if keys.contains(&Keycode::Escape) {
+                    self.cancel_click_key_capture();
+                } else if let Some(last_keys) = self.keys_pressed.clone() {
+                    self.capture_click_key(Some(&last_keys), &keys);
+                }
             }
         }
 
@@ -230,6 +311,7 @@ impl eframe::App for RustyAutoClickerApp {
         self.keys_pressed = Some(keys);
         self.ensure_hotkey_window();
         self.track_window_geometry(ctx);
+        self.tick_click_key_feedback_timeout();
 
         // Always request a repaint so hotkeys are polled every frame.
         // egui already throttles to ~60 fps so this does not cause excessive
@@ -245,6 +327,11 @@ impl eframe::App for RustyAutoClickerApp {
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
+        self.update_ui_scale(&ctx);
+        let sep_spacing = 6.0 * self.ui_scale;
+        let separator = |ui: &mut egui::Ui| {
+            ui.add(egui::Separator::default().spacing(sep_spacing));
+        };
 
         // The main window is ALWAYS rendered at its normal size — the
         // coordinate picker never replaces or resizes it. While picking
@@ -256,21 +343,44 @@ impl eframe::App for RustyAutoClickerApp {
 
         let click_amount = self.parsed_click_amount();
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        // `CentralPanel::default()`'s frame has a fixed (unscaled) 8px
+        // margin on every side, and `show_bottombar`'s panel has its own
+        // fixed 2px top margin on top of that — combined, that's ~10px of
+        // margin below the Start/Hold buttons that's entirely independent
+        // of the small, deliberate `gap` added in `show_autoclicker`,
+        // which is why the bottom gap looked noticeably bigger than the
+        // top one even though the button code adds equal space on both
+        // sides. Zeroing just the bottom inset here (leaving left/right/
+        // top at the normal 8px) puts `show_autoclicker`'s `gap` back in
+        // sole control of both the top AND bottom spacing around the
+        // buttons.
+        // No `ScrollArea` here — deliberately removed. Since the whole UI
+        // already scales down to fit the window (see `update_ui_scale`
+        // above), a scrollbar was redundant with that mechanism and just
+        // added its own gutter (clipping the rightmost pixels of every
+        // row) whenever content came up even slightly short. Instead,
+        // `WINDOW_MIN_HEIGHT` (see `defines.rs`) was calibrated so this
+        // content always fits at the enforced minimum window size without
+        // needing to scroll at all.
+        let mut central_frame = egui::Frame::central_panel(&ctx.global_style());
+        central_frame.inner_margin.bottom = 0;
+        egui::CentralPanel::default().frame(central_frame).show_inside(ui, |ui| {
             self.show_click_interval(ui);
-            ui.separator();
+            separator(ui);
+            self.show_random_offset(ui);
+            separator(ui);
             self.show_movement_speed(ui);
-            ui.separator();
+            separator(ui);
             self.show_buttons(ui);
-            ui.separator();
+            separator(ui);
             self.show_click_type(ui);
-            ui.separator();
+            separator(ui);
             self.show_click_amount(ui, click_amount);
-            ui.separator();
+            separator(ui);
             self.show_click_position(ui);
-            ui.separator();
+            separator(ui);
             self.show_infos(ui, &self.mouse, self.keys_pressed.as_deref().unwrap_or(&[]));
-            ui.separator();
+            separator(ui);
             self.show_autoclicker(ui);
         });
 

--- a/src/gui/sections/bars.rs
+++ b/src/gui/sections/bars.rs
@@ -2,18 +2,19 @@ use eframe::egui;
 
 use crate::{
     RustyAutoClickerApp,
+    settings::{self, Settings},
     types::{AppMode, InteractionMode},
 };
 
 impl RustyAutoClickerApp {
     pub fn show_topbar(&mut self, ui: &mut egui::Ui) {
         egui::Panel::top("top_panel").show_inside(ui, |ui| {
-            // The top panel is often a good place for a menu bar:
             egui::MenuBar::new().ui(ui, |ui| {
+                // ── Start / Stop button ──────────────────────────────────
                 if self.is_autoclicking() {
                     if ui.button(self.autoclick_button_label()).clicked() {
                         self.mode = InteractionMode::Idle;
-                    };
+                    }
                 } else {
                     if self.hotkey_window_open || self.is_holding() {
                         ui.disable();
@@ -24,8 +25,9 @@ impl RustyAutoClickerApp {
                 }
 
                 ui.separator();
-                ui.label("Settings: ");
+                ui.label("Settings:");
 
+                // ── Hotkeys window ───────────────────────────────────────
                 if ui
                     .add_enabled(
                         !self.is_autoclicking() && !self.is_holding(),
@@ -33,11 +35,38 @@ impl RustyAutoClickerApp {
                     )
                     .clicked()
                 {
-                    self.hotkey_window_open = true
-                };
+                    self.hotkey_window_open = true;
+                }
+
+                // ── Save button ──────────────────────────────────────────
+                if ui
+                    .add_enabled(
+                        !self.is_busy(),
+                        egui::Button::new(egui::RichText::new("💾").size(16.0))
+                            .min_size(egui::vec2(28.0, 24.0)),
+                    )
+                    .on_hover_text("Save current settings to disk")
+                    .clicked()
+                {
+                    settings::save_settings(&Settings::from_app(self));
+                }
+
+                // ── Reset button ─────────────────────────────────────────
+                let ctx = ui.ctx().clone();
+                if ui
+                    .add_enabled(
+                        !self.is_busy(),
+                        egui::Button::new(egui::RichText::new("↺").size(20.0))
+                            .min_size(egui::vec2(28.0, 24.0)),
+                    )
+                    .on_hover_text("Reset all settings to defaults")
+                    .clicked()
+                {
+                    self.reset_to_defaults(&ctx);
+                }
 
                 ui.separator();
-                ui.label("App Mode: ");
+                ui.label("App Mode:");
 
                 self.disable_if_busy(ui);
                 ui.selectable_value(&mut self.app_mode, AppMode::Bot, "🖥 Bot")
@@ -53,7 +82,10 @@ impl RustyAutoClickerApp {
             ui.with_layout(egui::Layout::bottom_up(egui::Align::RIGHT), |ui| {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 5.0;
-                    ui.hyperlink_to("eframe", "https://github.com/emilk/egui/tree/master/eframe");
+                    ui.hyperlink_to(
+                        "eframe",
+                        "https://github.com/emilk/egui/tree/master/eframe",
+                    );
                     ui.label(" and ");
                     ui.hyperlink_to("egui", "https://github.com/emilk/egui");
                     ui.label("powered by ");

--- a/src/gui/sections/bars.rs
+++ b/src/gui/sections/bars.rs
@@ -8,8 +8,97 @@ use crate::{
 
 impl RustyAutoClickerApp {
     pub fn show_topbar(&mut self, ui: &mut egui::Ui) {
-        egui::Panel::top("top_panel").show_inside(ui, |ui| {
+        // `Panel::top`'s default frame has a FIXED (unscaled) 2px top/
+        // bottom inner margin — fine back when the whole UI was a fixed
+        // size, but now that everything else (font, buttons, spacing)
+        // scales with `self.ui_scale`, that unscaled 2px stopped keeping
+        // pace: at default/smaller window sizes the row reads as
+        // artificially cramped/raised against the window's title bar
+        // compared to the pre-scaling layout, which always had comfortable
+        // breathing room here.
+        //
+        // ONLY the top inset is scaled — the bottom is deliberately left at
+        // 0. The row's content (the "|" separators especially) should sit
+        // flush against the thin border line `Panel::top`'s frame draws
+        // along its own bottom edge, not float above it with a gap on both
+        // sides. Padding only above (pushing the whole row down, away from
+        // the title bar) combined with zero padding below is what makes
+        // the separators' bottom tips actually touch that line instead of
+        // stopping short of it, matching the pre-scaling look.
+        //
+        // Simply shrinking this margin (tried at 3.0, then 0.0) was WRONG:
+        // since the bottom margin is fixed at 0, the border line `Panel::
+        // top`'s frame draws along its own bottom edge sits at exactly
+        // `vmargin + row_h` — shrinking `vmargin` alone drags that border
+        // line up right along with the row, instead of leaving it in
+        // place. The border (and the "|" separators, which stretch to
+        // fill the full row height and must keep touching it) has to stay
+        // exactly where it was; only the row's TEXT/ICONS should move up.
+        //
+        // Fix: move a fixed budget of pixels (`RAISE_PX`) OUT of the top
+        // margin and INTO `row_h` (see below) in equal amounts. Their SUM
+        // — and therefore `vmargin + row_h`, i.e. the border's position —
+        // stays exactly what it was at the original `vmargin = 4.0`
+        // baseline. The separator still stretches to fill the (now taller)
+        // `row_h`, so its bottom tip still lands exactly on the
+        // unmoved border. But the row's content is vertically CENTERED
+        // within `row_h`, and that center point shifts up by half of
+        // whatever was moved out of the margin — moving the budget from
+        // margin into row_h pulls the text up without moving the border
+        // or the separators' bottom tips at all. `RAISE_PX = 4.0` is the
+        // maximum this technique supports without going past a 0.0 margin
+        // (going further would need a different approach) — it yields a
+        // ~2px upward shift of the text at scale 1.0.
+        const BASE_MARGIN_PX: f32 = 4.0;
+        const RAISE_PX: f32 = 4.0;
+        let vmargin =
+            ((BASE_MARGIN_PX - RAISE_PX) * self.ui_scale).round().clamp(0.0, 127.0) as i8;
+        let mut top_frame = egui::Frame::side_top_panel(ui.style());
+        top_frame.inner_margin.top = vmargin;
+        top_frame.inner_margin.bottom = 0;
+        egui::Panel::top("top_panel").frame(top_frame).show_inside(ui, |ui| {
+            // Tried switching this to `horizontal_wrapped` so "App Mode:
+            // Bot Humanlike" could drop to its own line instead of
+            // clipping at the enforced minimum window size — reverted:
+            // `horizontal_wrapped`'s spacing is looser than `MenuBar`'s, so
+            // it wrapped even at the DEFAULT window width, adding an
+            // unwanted second line there and re-triggering the vertical
+            // scrollbar/clipping bug for every row below it. Left as
+            // `MenuBar` (non-wrapping) for now; the topbar can still clip a
+            // little at the exact enforced minimum size, a smaller and
+            // separate issue from the content-row clipping this session
+            // fixed.
             egui::MenuBar::new().ui(ui, |ui| {
+                // Reserve the row's FINAL height up front, before adding
+                // any widget. MenuBar itself already reserves
+                // `interact_size.y` internally before it hands control to
+                // this closure — but that's only tall enough for plain
+                // buttons/labels, not the bigger Save/Reset icon glyphs
+                // added below (see that section's note). Widgets already
+                // placed in a row are NOT retroactively re-centered if a
+                // later widget turns out to need more height — only the
+                // container's reported size grows — so if the row's true
+                // height isn't known until partway through (previously:
+                // by the Save/Reset buttons), everything added before that
+                // point centers against the wrong, smaller height while
+                // everything after centers correctly. That mismatch is
+                // exactly what made Start/Settings/HotKeys look "raised"
+                // relative to App Mode. Reserving the real final height
+                // here, before the first widget, is what actually fixes
+                // it: `+6.0 * self.ui_scale` is the measured amount the
+                // "↺" reset glyph needs beyond the plain interact_size.y
+                // floor at its original (bigger, preferred) 20pt size.
+                //
+                // `+ RAISE_PX * self.ui_scale` on top of that is the other
+                // half of the margin/row_h trade described above `vmargin`
+                // — it makes this row taller by exactly what was removed
+                // from the top margin, so the border position (margin +
+                // row_h) is unchanged, while the row's vertically-centered
+                // content shifts up within the extra room.
+                let row_h =
+                    ui.spacing().interact_size.y + (6.0 + RAISE_PX) * self.ui_scale;
+                ui.set_min_height(row_h);
+
                 // ── Start / Stop button ──────────────────────────────────
                 if self.is_autoclicking() {
                     if ui.button(self.autoclick_button_label()).clicked() {
@@ -31,19 +120,34 @@ impl RustyAutoClickerApp {
                 if ui
                     .add_enabled(
                         !self.is_autoclicking() && !self.is_holding(),
-                        egui::Button::new("⌨ Hotkeys"),
+                        egui::Button::new("⌨ HotKeys"),
                     )
                     .clicked()
                 {
                     self.hotkey_window_open = true;
                 }
 
-                // ── Save button ──────────────────────────────────────────
+                // ── Save / Reset icon buttons ────────────────────────────
+                // Before the responsive-scaling work, these buttons used a
+                // FIXED `min_size(vec2(28.0, 24.0))` — a height of exactly
+                // 24px, independent of the row's own reserved height. That
+                // 24px (scaled) is what actually reproduces "how it looked
+                // before" — using `row_h` here instead (as an earlier
+                // version of this fix did) subtly changed the button's
+                // proportions and vertical centering versus the original.
+                // `row_h` (reserved via `ui.set_min_height` above) is what
+                // keeps this row's OTHER widgets — Start/Settings/HotKeys —
+                // aligned with App Mode; it doesn't need to also be this
+                // button's own height for that alignment to hold, since
+                // `MenuBar`'s row centers each widget within the row's
+                // overall (already-reserved) height regardless of that
+                // widget's own min_size.
+                let icon_size = egui::vec2(28.0 * self.ui_scale, 24.0 * self.ui_scale);
                 if ui
                     .add_enabled(
                         !self.is_busy(),
-                        egui::Button::new(egui::RichText::new("💾").size(16.0))
-                            .min_size(egui::vec2(28.0, 24.0)),
+                        egui::Button::new(egui::RichText::new("💾").size(16.0 * self.ui_scale))
+                            .min_size(icon_size),
                     )
                     .on_hover_text("Save current settings to disk")
                     .clicked()
@@ -51,13 +155,12 @@ impl RustyAutoClickerApp {
                     settings::save_settings(&Settings::from_app(self));
                 }
 
-                // ── Reset button ─────────────────────────────────────────
                 let ctx = ui.ctx().clone();
                 if ui
                     .add_enabled(
                         !self.is_busy(),
-                        egui::Button::new(egui::RichText::new("↺").size(20.0))
-                            .min_size(egui::vec2(28.0, 24.0)),
+                        egui::Button::new(egui::RichText::new("↺").size(20.0 * self.ui_scale))
+                            .min_size(icon_size),
                     )
                     .on_hover_text("Reset all settings to defaults")
                     .clicked()
@@ -71,17 +174,44 @@ impl RustyAutoClickerApp {
                 self.disable_if_busy(ui);
                 ui.selectable_value(&mut self.app_mode, AppMode::Bot, "🖥 Bot")
                     .on_hover_text("Autoclick as fast as possible");
-                ui.selectable_value(&mut self.app_mode, AppMode::Humanlike, "😆 Humanlike")
+                ui.selectable_value(&mut self.app_mode, AppMode::Humanlike, "😆 Human")
                     .on_hover_text("Autoclick emulating human clicking");
             });
         });
     }
 
     pub fn show_bottombar(&mut self, ui: &mut egui::Ui) {
-        egui::Panel::bottom("bottom_panel").show_inside(ui, |ui| {
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::RIGHT), |ui| {
-                ui.horizontal(|ui| {
+        // Zero the panel's own (fixed, unscaled) top inner margin — see the
+        // matching note on `CentralPanel`'s frame in `gui/mod.rs::ui()`.
+        // Without this, that fixed margin stacked with `CentralPanel`'s own
+        // bottom margin made the gap below the Start/Hold buttons visibly
+        // bigger than the deliberate `gap` added above them, even though
+        // the button code adds equal space on both sides.
+        let mut bottom_frame = egui::Frame::side_top_panel(ui.style());
+        bottom_frame.inner_margin.top = 0;
+        egui::Panel::bottom("bottom_panel").frame(bottom_frame).show_inside(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.weak("⚠ Hold HotKeys*")
+                    .on_hover_text(
+                        "While the window is minimized, a quick tap of a hotkey may not \
+                         always register — holding it down briefly is more reliable in \
+                         that case. This doesn't apply while the window is just behind \
+                         other windows, only while actually minimized."
+                    );
+
+                // right_to_left reverses visual order relative to add
+                // order — the item added FIRST ends up RIGHTMOST. To read
+                // left-to-right as "rusty-autoclicker powered by egui and
+                // eframe [separator] [debug warning]", they have to be
+                // added in exactly the reverse of that: debug warning,
+                // separator, eframe, " and ", egui, "powered by ",
+                // rusty-autoclicker. (An earlier version of this had that
+                // reversal backwards, which is why it used to render as
+                // "eframe and egui powered by rusty-autoclicker" instead.)
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.spacing_mut().item_spacing.x = 5.0;
+                    egui::warn_if_debug_build(ui);
+                    ui.separator();
                     ui.hyperlink_to(
                         "eframe",
                         "https://github.com/emilk/egui/tree/master/eframe",
@@ -93,8 +223,6 @@ impl RustyAutoClickerApp {
                         "rusty-autoclicker",
                         "https://github.com/MrTanoshii/rusty-autoclicker",
                     );
-                    ui.separator();
-                    egui::warn_if_debug_build(ui);
                 });
             });
         });

--- a/src/gui/sections/buttons.rs
+++ b/src/gui/sections/buttons.rs
@@ -9,193 +9,277 @@ macro_rules! key_option {
         $ui.selectable_value(
             &mut $self.click_btn,
             ClickButton::Key(Key::$variant),
-            stringify!($variant),
+            crate::utils::abbreviate_key(Key::$variant),
         );
     };
 }
 
 impl RustyAutoClickerApp {
     pub fn show_buttons(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Buttons");
-            if ui
-                .add(egui::RadioButton::new(
-                    matches!(self.click_btn, ClickButton::Mouse(_)),
-                    "Mouse",
-                ))
-                .clicked()
-            {
-                self.click_btn = ClickButton::Mouse(Button::Left);
-            }
-            if ui
-                .add(egui::RadioButton::new(
-                    matches!(self.click_btn, ClickButton::Key(_)),
-                    "Keyboard",
-                ))
-                .clicked()
-            {
-                self.click_btn = ClickButton::Key(Key::Space);
-            }
+        super::wrapping_field_row(
+            ui,
+            self,
+            |state, ui| {
+                ui.label("Buttons");
+                ui.add_enabled_ui(!state.is_setting_click_key(), |ui| {
+                    if ui
+                        .add(egui::RadioButton::new(
+                            matches!(state.click_btn, ClickButton::Mouse(_)),
+                            "Mouse",
+                        ))
+                        .clicked()
+                    {
+                        state.click_btn = ClickButton::Mouse(Button::Left);
+                        // Leaving Keyboard mode entirely — a leftover "Set
+                        // to X" for the key you just left makes no sense
+                        // here.
+                        state.click_key_capture_error = None;
+                        state.click_key_capture_feedback = None;
+                        state.click_key_capture_feedback_set_at = None;
+                    }
+                    if ui
+                        .add(egui::RadioButton::new(
+                            matches!(state.click_btn, ClickButton::Key(_)),
+                            "Keyboard",
+                        ))
+                        .clicked()
+                    {
+                        // Restore whatever key was last used in Keyboard
+                        // mode instead of always resetting to Space.
+                        state.click_btn = ClickButton::Key(state.last_keyboard_key);
+                    }
+                });
+            },
+            |state, ui| match state.click_btn {
+                ClickButton::Mouse(_) => state.show_mouse_buttons(ui),
+                ClickButton::Key(_) => state.show_keyboard_buttons(ui),
+            },
+        );
 
-            match self.click_btn {
-                ClickButton::Mouse(_) => self.show_mouse_buttons(ui),
-                ClickButton::Key(_) => self.show_keyboard_buttons(ui),
+        // Remember the last keyboard key across Mouse<->Keyboard toggles,
+        // and give ONE uniform "Set to X" confirmation whether the key
+        // came from the dropdown or from Press-Key capture — from the
+        // user's perspective both are equally "I successfully set the
+        // key", so both should confirm the same way instead of only the
+        // capture flow saying anything.
+        if let ClickButton::Key(k) = self.click_btn {
+            self.last_keyboard_key = k;
+            if self.click_btn != self.last_seen_click_btn {
+                self.click_key_capture_error = None;
+                self.click_key_capture_feedback =
+                    Some(format!("Set to \"{}\"", crate::utils::abbreviate_key(k)));
+                self.click_key_capture_feedback_set_at = Some(std::time::Instant::now());
             }
-        });
+        }
+        self.last_seen_click_btn = self.click_btn;
+
+        // IMPORTANT: this must NOT be nested inside the `horizontal_wrapped`
+        // above. It used to live at the end of `show_keyboard_buttons`,
+        // called with that same row's `ui` — i.e. a wrapped horizontal
+        // layout nested inside another wrapped horizontal layout sharing one
+        // cursor. That combination corrupts egui's row-height bookkeeping
+        // and produces a large phantom blank gap that pushes every section
+        // below it far down (sometimes off the bottom of the window). It
+        // only appeared after a successful "Press Key" capture because that
+        // was the only path that set `click_key_capture_feedback`, which is
+        // what triggered the nested call — the manual dropdown never sets
+        // it, which is why the dropdown path never broke.
+        //
+        // This row takes up NO space at all when there's nothing to show —
+        // it only appears (and the content below it shifts down slightly)
+        // while an error or "Set to X" confirmation is actually visible,
+        // then collapses back once it clears. The window itself is never
+        // resized for this either way; on the rare frame where showing it
+        // pushes total content height a few pixels past what fits, the
+        // `ScrollArea` safety net in `gui/mod.rs::ui()` absorbs it rather
+        // than clipping.
+        if let Some(err) = self.click_key_capture_error.clone() {
+            ui.horizontal_wrapped(|ui| {
+                ui.colored_label(egui::Color32::from_rgb(220, 80, 80), err);
+            });
+        } else if let Some(msg) = self.click_key_capture_feedback.clone() {
+            ui.horizontal_wrapped(|ui| {
+                ui.colored_label(egui::Color32::from_rgb(90, 200, 120), msg);
+            });
+        }
     }
 
     fn show_mouse_buttons(&mut self, ui: &mut egui::Ui) {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-            egui::ComboBox::from_id_salt("mouse_button")
-                .selected_text(format!("{}", self.click_btn))
-                .show_ui(ui, |ui| {
+        // Caller (`show_buttons`, via `wrapping_field_row`) already places
+        // this closure inside a right-to-left layout — no need to nest
+        // another one here.
+        egui::ComboBox::from_id_salt("mouse_button")
+            .selected_text(format!("{}", self.click_btn))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut self.click_btn,
+                    ClickButton::Mouse(Button::Left),
+                    "Left",
+                );
+                ui.selectable_value(
+                    &mut self.click_btn,
+                    ClickButton::Mouse(Button::Right),
+                    "Right",
+                );
+                // rdev's macOS backend can only simulate Left/Right.
+                if !cfg!(target_os = "macos") {
                     ui.selectable_value(
                         &mut self.click_btn,
-                        ClickButton::Mouse(Button::Left),
-                        "Left",
+                        ClickButton::Mouse(Button::Middle),
+                        "Middle",
                     );
-                    ui.selectable_value(
-                        &mut self.click_btn,
-                        ClickButton::Mouse(Button::Right),
-                        "Right",
-                    );
-                    // rdev's macOS backend can only simulate Left/Right.
-                    if !cfg!(target_os = "macos") {
-                        ui.selectable_value(
-                            &mut self.click_btn,
-                            ClickButton::Mouse(Button::Middle),
-                            "Middle",
-                        );
-                    }
-                });
-        });
+                }
+            });
     }
 
     fn show_keyboard_buttons(&mut self, ui: &mut egui::Ui) {
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-            egui::ComboBox::from_id_salt("keyboard_button")
-                .selected_text(format!("{}", self.click_btn))
-                .show_ui(ui, |ui| {
-                    // Modifier keys
-                    key_option!(ui, self, Alt);
-                    key_option!(ui, self, AltGr);
-                    key_option!(ui, self, CapsLock);
-                    key_option!(ui, self, ControlLeft);
-                    key_option!(ui, self, ControlRight);
-                    key_option!(ui, self, MetaLeft);
-                    key_option!(ui, self, MetaRight);
-                    key_option!(ui, self, ShiftLeft);
-                    key_option!(ui, self, ShiftRight);
-                    key_option!(ui, self, Function);
+        // Same note as `show_mouse_buttons` above — already inside a
+        // right-to-left layout from the caller.
+        {
+            if self.is_setting_click_key() {
+                if ui.button("Cancel").clicked() {
+                    self.cancel_click_key_capture();
+                }
+                ui.label("Press any key...")
+                    .on_hover_text(
+                        "Num Lock, Print Screen, Scroll Lock, and Pause can't be detected \
+                         this way (a limitation of the underlying input library, not this \
+                         app) — pick those from the dropdown instead."
+                    );
+            } else {
+                egui::ComboBox::from_id_salt("keyboard_button")
+                    .selected_text(format!("{}", self.click_btn))
+                    .show_ui(ui, |ui| {
+                        // Modifier keys
+                        key_option!(ui, self, Alt);
+                        key_option!(ui, self, AltGr);
+                        key_option!(ui, self, CapsLock);
+                        key_option!(ui, self, ControlLeft);
+                        key_option!(ui, self, ControlRight);
+                        key_option!(ui, self, MetaLeft);
+                        key_option!(ui, self, MetaRight);
+                        key_option!(ui, self, ShiftLeft);
+                        key_option!(ui, self, ShiftRight);
+                        key_option!(ui, self, Function);
 
-                    // Navigation
-                    key_option!(ui, self, UpArrow);
-                    key_option!(ui, self, DownArrow);
-                    key_option!(ui, self, LeftArrow);
-                    key_option!(ui, self, RightArrow);
-                    key_option!(ui, self, Home);
-                    key_option!(ui, self, End);
-                    key_option!(ui, self, PageUp);
-                    key_option!(ui, self, PageDown);
-                    key_option!(ui, self, Insert);
-                    key_option!(ui, self, Delete);
-                    key_option!(ui, self, Escape);
-                    key_option!(ui, self, Return);
-                    key_option!(ui, self, Tab);
-                    key_option!(ui, self, Space);
+                        // Navigation
+                        key_option!(ui, self, UpArrow);
+                        key_option!(ui, self, DownArrow);
+                        key_option!(ui, self, LeftArrow);
+                        key_option!(ui, self, RightArrow);
+                        key_option!(ui, self, Home);
+                        key_option!(ui, self, End);
+                        key_option!(ui, self, PageUp);
+                        key_option!(ui, self, PageDown);
+                        key_option!(ui, self, Insert);
+                        key_option!(ui, self, Delete);
+                        key_option!(ui, self, Backspace);
+                        key_option!(ui, self, Escape);
+                        key_option!(ui, self, Return);
+                        key_option!(ui, self, Tab);
+                        key_option!(ui, self, Space);
 
-                    // Function keys
-                    key_option!(ui, self, F1);
-                    key_option!(ui, self, F2);
-                    key_option!(ui, self, F3);
-                    key_option!(ui, self, F4);
-                    key_option!(ui, self, F5);
-                    key_option!(ui, self, F6);
-                    key_option!(ui, self, F7);
-                    key_option!(ui, self, F8);
-                    key_option!(ui, self, F9);
-                    key_option!(ui, self, F10);
-                    key_option!(ui, self, F11);
-                    key_option!(ui, self, F12);
+                        // Function keys
+                        key_option!(ui, self, F1);
+                        key_option!(ui, self, F2);
+                        key_option!(ui, self, F3);
+                        key_option!(ui, self, F4);
+                        key_option!(ui, self, F5);
+                        key_option!(ui, self, F6);
+                        key_option!(ui, self, F7);
+                        key_option!(ui, self, F8);
+                        key_option!(ui, self, F9);
+                        key_option!(ui, self, F10);
+                        key_option!(ui, self, F11);
+                        key_option!(ui, self, F12);
 
-                    // Print/Lock
-                    key_option!(ui, self, PrintScreen);
-                    key_option!(ui, self, ScrollLock);
-                    key_option!(ui, self, Pause);
-                    key_option!(ui, self, NumLock);
+                        // Print/Lock
+                        key_option!(ui, self, PrintScreen);
+                        key_option!(ui, self, ScrollLock);
+                        key_option!(ui, self, Pause);
+                        key_option!(ui, self, NumLock);
 
-                    // Top row number keys and symbols
-                    key_option!(ui, self, BackQuote);
-                    key_option!(ui, self, Num1);
-                    key_option!(ui, self, Num2);
-                    key_option!(ui, self, Num3);
-                    key_option!(ui, self, Num4);
-                    key_option!(ui, self, Num5);
-                    key_option!(ui, self, Num6);
-                    key_option!(ui, self, Num7);
-                    key_option!(ui, self, Num8);
-                    key_option!(ui, self, Num9);
-                    key_option!(ui, self, Num0);
-                    key_option!(ui, self, Minus);
-                    key_option!(ui, self, Equal);
+                        // Top row number keys and symbols
+                        key_option!(ui, self, BackQuote);
+                        key_option!(ui, self, Num1);
+                        key_option!(ui, self, Num2);
+                        key_option!(ui, self, Num3);
+                        key_option!(ui, self, Num4);
+                        key_option!(ui, self, Num5);
+                        key_option!(ui, self, Num6);
+                        key_option!(ui, self, Num7);
+                        key_option!(ui, self, Num8);
+                        key_option!(ui, self, Num9);
+                        key_option!(ui, self, Num0);
+                        key_option!(ui, self, Minus);
+                        key_option!(ui, self, Equal);
 
-                    // Letter keys
-                    key_option!(ui, self, KeyA);
-                    key_option!(ui, self, KeyB);
-                    key_option!(ui, self, KeyC);
-                    key_option!(ui, self, KeyD);
-                    key_option!(ui, self, KeyE);
-                    key_option!(ui, self, KeyF);
-                    key_option!(ui, self, KeyG);
-                    key_option!(ui, self, KeyH);
-                    key_option!(ui, self, KeyI);
-                    key_option!(ui, self, KeyJ);
-                    key_option!(ui, self, KeyK);
-                    key_option!(ui, self, KeyL);
-                    key_option!(ui, self, KeyM);
-                    key_option!(ui, self, KeyN);
-                    key_option!(ui, self, KeyO);
-                    key_option!(ui, self, KeyP);
-                    key_option!(ui, self, KeyQ);
-                    key_option!(ui, self, KeyR);
-                    key_option!(ui, self, KeyS);
-                    key_option!(ui, self, KeyT);
-                    key_option!(ui, self, KeyU);
-                    key_option!(ui, self, KeyV);
-                    key_option!(ui, self, KeyW);
-                    key_option!(ui, self, KeyX);
-                    key_option!(ui, self, KeyY);
-                    key_option!(ui, self, KeyZ);
+                        // Letter keys
+                        key_option!(ui, self, KeyA);
+                        key_option!(ui, self, KeyB);
+                        key_option!(ui, self, KeyC);
+                        key_option!(ui, self, KeyD);
+                        key_option!(ui, self, KeyE);
+                        key_option!(ui, self, KeyF);
+                        key_option!(ui, self, KeyG);
+                        key_option!(ui, self, KeyH);
+                        key_option!(ui, self, KeyI);
+                        key_option!(ui, self, KeyJ);
+                        key_option!(ui, self, KeyK);
+                        key_option!(ui, self, KeyL);
+                        key_option!(ui, self, KeyM);
+                        key_option!(ui, self, KeyN);
+                        key_option!(ui, self, KeyO);
+                        key_option!(ui, self, KeyP);
+                        key_option!(ui, self, KeyQ);
+                        key_option!(ui, self, KeyR);
+                        key_option!(ui, self, KeyS);
+                        key_option!(ui, self, KeyT);
+                        key_option!(ui, self, KeyU);
+                        key_option!(ui, self, KeyV);
+                        key_option!(ui, self, KeyW);
+                        key_option!(ui, self, KeyX);
+                        key_option!(ui, self, KeyY);
+                        key_option!(ui, self, KeyZ);
 
-                    // Punctuation and symbol keys
-                    key_option!(ui, self, LeftBracket);
-                    key_option!(ui, self, RightBracket);
-                    key_option!(ui, self, SemiColon);
-                    key_option!(ui, self, Quote);
-                    key_option!(ui, self, BackSlash);
-                    key_option!(ui, self, IntlBackslash);
-                    key_option!(ui, self, Comma);
-                    key_option!(ui, self, Dot);
-                    key_option!(ui, self, Slash);
+                        // Punctuation and symbol keys
+                        key_option!(ui, self, LeftBracket);
+                        key_option!(ui, self, RightBracket);
+                        key_option!(ui, self, SemiColon);
+                        key_option!(ui, self, Quote);
+                        key_option!(ui, self, BackSlash);
+                        key_option!(ui, self, IntlBackslash);
+                        key_option!(ui, self, Comma);
+                        key_option!(ui, self, Dot);
+                        key_option!(ui, self, Slash);
 
-                    // Keypad
-                    key_option!(ui, self, KpReturn);
-                    key_option!(ui, self, KpMinus);
-                    key_option!(ui, self, KpPlus);
-                    key_option!(ui, self, KpMultiply);
-                    key_option!(ui, self, KpDivide);
-                    key_option!(ui, self, Kp0);
-                    key_option!(ui, self, Kp1);
-                    key_option!(ui, self, Kp2);
-                    key_option!(ui, self, Kp3);
-                    key_option!(ui, self, Kp4);
-                    key_option!(ui, self, Kp5);
-                    key_option!(ui, self, Kp6);
-                    key_option!(ui, self, Kp7);
-                    key_option!(ui, self, Kp8);
-                    key_option!(ui, self, Kp9);
-                    key_option!(ui, self, KpDelete);
-                });
-        });
+                        // Keypad
+                        key_option!(ui, self, KpReturn);
+                        key_option!(ui, self, KpMinus);
+                        key_option!(ui, self, KpPlus);
+                        key_option!(ui, self, KpMultiply);
+                        key_option!(ui, self, KpDivide);
+                        key_option!(ui, self, Kp0);
+                        key_option!(ui, self, Kp1);
+                        key_option!(ui, self, Kp2);
+                        key_option!(ui, self, Kp3);
+                        key_option!(ui, self, Kp4);
+                        key_option!(ui, self, Kp5);
+                        key_option!(ui, self, Kp6);
+                        key_option!(ui, self, Kp7);
+                        key_option!(ui, self, Kp8);
+                        key_option!(ui, self, Kp9);
+                        key_option!(ui, self, KpDelete);
+                    });
+
+                if ui.button("🎯 Press Key").on_hover_text(
+                    "Click, then press the key you want the autoclicker to use.\n\
+                     Note: Num Lock, Print Screen, Scroll Lock, and Pause can't be \
+                     captured this way — select them from the dropdown."
+                ).clicked() {
+                    self.enter_click_key_capture();
+                }
+            }
+        }
     }
 }

--- a/src/gui/sections/click_config.rs
+++ b/src/gui/sections/click_config.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Context};
+use eframe::egui;
 
 use crate::{
     RustyAutoClickerApp,
@@ -73,7 +73,7 @@ impl RustyAutoClickerApp {
         });
     }
 
-    pub fn show_click_position(&mut self, ui: &mut egui::Ui, ctx: &Context) {
+    pub fn show_click_position(&mut self, ui: &mut egui::Ui) {
         ui.horizontal_wrapped(|ui| {
             ui.label("Click Position");
             self.disable_if_busy(ui);
@@ -81,7 +81,7 @@ impl RustyAutoClickerApp {
                 .add_sized([80.0f32, 16.0f32], egui::widgets::Button::new("Set Coords"))
                 .clicked()
             {
-                Self::enter_coordinate_setting(self, ctx);
+                self.enter_coordinate_setting(ui.ctx());
             };
             ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                 self.disable_if_busy(ui);
@@ -98,19 +98,9 @@ impl RustyAutoClickerApp {
                 );
                 ui.label("X");
 
-                if ui
-                    .selectable_value(&mut self.click_position, ClickPosition::Coord, "Coords")
-                    .clicked()
-                {
-                    self.key_pressed_set_coord = true;
-                };
+                ui.selectable_value(&mut self.click_position, ClickPosition::Coord, "Coords");
                 ui.separator();
-                if ui
-                    .selectable_value(&mut self.click_position, ClickPosition::Mouse, "Mouse")
-                    .clicked()
-                {
-                    self.key_pressed_set_coord = false;
-                };
+                ui.selectable_value(&mut self.click_position, ClickPosition::Mouse, "Mouse");
             });
         });
     }

--- a/src/gui/sections/click_config.rs
+++ b/src/gui/sections/click_config.rs
@@ -2,106 +2,194 @@ use eframe::egui;
 
 use crate::{
     RustyAutoClickerApp,
+    defines::DEFAULT_RANDOM_OFFSET_STR,
     types::{ClickPosition, ClickType},
 };
 
 impl RustyAutoClickerApp {
     pub fn show_click_interval(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Click Interval");
+        // Base widths are the ORIGINAL fixed pixel values from before any
+        // of this responsive work — scaling by `self.ui_scale` reproduces
+        // that exact look at the default window size (scale == 1.0) and
+        // shrinks/grows every field in lockstep with the font and
+        // everything else as the window is resized.
+        let field_w = 40.0 * self.ui_scale;
+        let label = "Click Interval";
 
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+        super::wrapping_field_row(
+            ui,
+            self,
+            |_state, ui| {
+                ui.label(label);
+            },
+            |state, ui| {
                 ui.label("ms");
-                self.disable_if_busy(ui);
+                state.disable_if_busy(ui);
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.ms_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.ms_str)
+                        .desired_width(field_w)
                         .hint_text("0"),
                 );
 
                 ui.label("sec");
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.sec_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.sec_str)
+                        .desired_width(field_w)
                         .hint_text("0"),
                 );
 
                 ui.label("min");
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.min_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.min_str)
+                        .desired_width(field_w)
                         .hint_text("0"),
                 );
 
                 ui.label("hr");
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.hr_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.hr_str)
+                        .desired_width(field_w)
                         .hint_text("0"),
                 );
-            });
-        });
+            },
+        );
+    }
+
+    /// "Random Offset (+/-)" — an optional +/- jitter (ms) applied on top
+    /// of the base Click Interval, matching the concept from OP Auto
+    /// Clicker's "Random offset +-" control. Off by default; the field is
+    /// only editable while the checkbox is on. Actually wired into click
+    /// timing in `app.rs::roll_next_interval` / `current_interval_ms`, not
+    /// just cosmetic.
+    pub fn show_random_offset(&mut self, ui: &mut egui::Ui) {
+        let field_w = 40.0 * self.ui_scale;
+        let label = "Random Offset (+/-)";
+
+        super::wrapping_field_row(
+            ui,
+            self,
+            |state, ui| {
+                state.disable_if_busy(ui);
+                ui.checkbox(&mut state.random_offset_enabled, label);
+            },
+            |state, ui| {
+                ui.label("ms");
+                ui.add_enabled(
+                    state.random_offset_enabled,
+                    egui::TextEdit::singleline(&mut state.random_offset_str)
+                        .desired_width(field_w)
+                        .hint_text(DEFAULT_RANDOM_OFFSET_STR),
+                );
+            },
+        );
     }
 
     pub fn show_click_type(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Click Type");
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                self.disable_if_busy(ui);
-                ui.selectable_value(&mut self.click_type, ClickType::Single, "Single");
-                ui.selectable_value(&mut self.click_type, ClickType::Double, "Double");
-            });
-        });
+        let label = "Click Type";
+
+        super::wrapping_field_row(
+            ui,
+            self,
+            |_state, ui| {
+                ui.label(label);
+            },
+            |state, ui| {
+                state.disable_if_busy(ui);
+                ui.selectable_value(&mut state.click_type, ClickType::Double, "Double");
+                ui.selectable_value(&mut state.click_type, ClickType::Single, "Single");
+            },
+        );
     }
 
     pub fn show_click_amount(&mut self, ui: &mut egui::Ui, click_amount: u64) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Click Amount (0 = forever)");
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                self.disable_if_busy(ui);
+        let field_w = 40.0 * self.ui_scale;
+        let label = "Click Amount (0 = forever)";
+
+        super::wrapping_field_row(
+            ui,
+            self,
+            |_state, ui| {
+                ui.label(label);
+            },
+            |state, ui| {
+                state.disable_if_busy(ui);
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.click_amount_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.click_amount_str)
+                        .desired_width(field_w)
                         .hint_text("0"),
                 );
-                if self.is_autoclicking() && click_amount > 0u64 {
-                    let remaining_clicks = click_amount.saturating_sub(self.click_counter);
+                if state.is_autoclicking() && click_amount > 0u64 {
+                    let remaining_clicks = click_amount.saturating_sub(state.click_counter);
                     let remaining_text = format!("Remaining {remaining_clicks:?}");
                     ui.label(remaining_text);
                 }
-            });
-        });
+            },
+        );
     }
 
     pub fn show_click_position(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Click Position");
-            self.disable_if_busy(ui);
-            if ui
-                .add_sized([80.0f32, 16.0f32], egui::widgets::Button::new("Set Coords"))
-                .clicked()
-            {
-                self.enter_coordinate_setting(ui.ctx());
-            };
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                self.disable_if_busy(ui);
+        let scale = self.ui_scale;
+        let coord_field_w = 50.0 * scale;
+        let set_coords_size = egui::vec2(80.0 * scale, 16.0 * scale);
+
+        super::wrapping_field_row(
+            ui,
+            self,
+            |state, ui| {
+                ui.label("Click Mode");
+                state.disable_if_busy(ui);
+
+                // Mode toggle lives on the left, where "Set Coords" used to
+                // be — this is the actual "will it click at a fixed X/Y or
+                // wherever the mouse currently is" switch, so it gets the
+                // more prominent left-side spot instead of being easy to
+                // mistake for a coordinate readout next to the X/Y fields.
+                ui.selectable_value(&mut state.click_position, ClickPosition::Mouse, "Mouse")
+                    .on_hover_text(
+                        "Click wherever the mouse cursor currently is, instead of a fixed \
+                         saved position. Useful for autoclicking under manual mouse control."
+                    );
+
+                // Reverted to the original tight spacing (no add_space
+                // padding) per feedback. `ui.separator()` only ever draws a
+                // 1px hairline with no way to thicken it directly, so this
+                // paints a small rect instead to get a genuinely bolder
+                // divider.
+                let divider_color = ui.visuals().widgets.noninteractive.bg_stroke.color;
+                let (divider_rect, _) = ui.allocate_exact_size(
+                    egui::vec2(3.0 * scale, 18.0 * scale),
+                    egui::Sense::hover(),
+                );
+                ui.painter().rect_filled(divider_rect, 0.0, divider_color);
+
+                ui.selectable_value(&mut state.click_position, ClickPosition::Coord, "Fixed")
+                    .on_hover_text(
+                        "Always click at the saved X/Y coordinates below, regardless of \
+                         where the mouse cursor currently is. Use \"Set Coords\" to pick \
+                         that fixed position."
+                    );
+            },
+            |state, ui| {
+                state.disable_if_busy(ui);
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.click_y_str)
-                        .desired_width(50.0f32)
+                    egui::TextEdit::singleline(&mut state.click_y_str)
+                        .desired_width(coord_field_w)
                         .hint_text("0"),
                 );
                 ui.label("Y");
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.click_x_str)
-                        .desired_width(50.0f32)
+                    egui::TextEdit::singleline(&mut state.click_x_str)
+                        .desired_width(coord_field_w)
                         .hint_text("0"),
                 );
                 ui.label("X");
-
-                ui.selectable_value(&mut self.click_position, ClickPosition::Coord, "Coords");
-                ui.separator();
-                ui.selectable_value(&mut self.click_position, ClickPosition::Mouse, "Mouse");
-            });
-        });
+                if ui
+                    .add_sized(set_coords_size, egui::widgets::Button::new("Set Coords"))
+                    .clicked()
+                {
+                    state.enter_coordinate_setting(ui.ctx());
+                };
+            },
+        );
     }
 }

--- a/src/gui/sections/mod.rs
+++ b/src/gui/sections/mod.rs
@@ -11,28 +11,98 @@ mod bars;
 mod buttons;
 mod click_config;
 
+/// Renders a settings row as a left side (a label, and optionally a few
+/// more widgets) with a right-aligned control group — matching the
+/// original fixed layout at normal window sizes.
+///
+/// The right-aligned group is given an EXPLICIT bounded size via
+/// `allocate_ui_with_layout`, sized to whatever's ACTUALLY left on the row
+/// after the left side was drawn (`ui.available_width()`, read right after
+/// `add_left` runs) — rather than an open-ended
+/// `ui.with_layout(Layout::right_to_left(..))`. The latter anchors its
+/// content to the full max_rect it inherits, which is NOT reliably
+/// "whatever's left after the label" — at small window sizes the
+/// right-aligned group could still reach past the window edge and clip
+/// even though there was technically enough room for it. This was the
+/// actual cause of "Humanlike"/"px/s"/etc. getting cut off at the
+/// enforced minimum window size. Bounding the box to the row's real
+/// remaining width makes that structurally impossible — the box can
+/// never extend past the window edge because it's sized FROM that edge —
+/// while still rendering flush-right exactly like the original fixed
+/// layout when there's room to spare.
+///
+/// Deliberately uses a plain `ui.horizontal` here, NOT
+/// `ui.horizontal_wrapped` — under a wrapping layout, `available_width()`
+/// reports the whole line's width rather than what's left after the
+/// cursor's current position (egui can't know in advance whether a given
+/// item will wrap), so the "remaining width" read after `add_left` would
+/// come back far too large. A plain (non-wrapping) horizontal layout's
+/// `available_width()` genuinely shrinks as the cursor advances, so it's
+/// the only one of the two that gives an accurate number here. The
+/// trade-off is that at the very edge of the enforced minimum window size
+/// the right-aligned group can end up squeezed rather than dropping to
+/// its own line — but since its box can never exceed the true remaining
+/// width, it can never clip off the window either.
+///
+/// Takes `state` (almost always `self`) as an explicit parameter rather
+/// than letting `add_left`/`add_right` capture it by closure — two
+/// closures that each capture `self` can't both be constructed as
+/// arguments to the same call even though only one of them ever actually
+/// runs (the borrow checker can't see that), so `state` is threaded
+/// through the callback signature instead.
+pub(super) fn wrapping_field_row<T>(
+    ui: &mut egui::Ui,
+    state: &mut T,
+    add_left: impl FnOnce(&mut T, &mut egui::Ui),
+    add_right: impl FnOnce(&mut T, &mut egui::Ui),
+) {
+    let right_height = ui.spacing().interact_size.y;
+    ui.horizontal(|ui| {
+        add_left(state, ui);
+        let right_width = ui.available_width().max(0.0);
+        ui.allocate_ui_with_layout(
+            egui::vec2(right_width, right_height),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| add_right(state, ui),
+        );
+    });
+}
+
 impl RustyAutoClickerApp {
     pub fn show_movement_speed(&mut self, ui: &mut egui::Ui) {
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Movement speed (Humanlike only)");
+        // Base field width is the ORIGINAL fixed pixel value from before
+        // any of this responsive work — scaling it by `self.ui_scale`
+        // reproduces that exact original look at the default window size
+        // (scale == 1.0) and shrinks/grows it in lockstep with the font
+        // and everything else as the window is resized, rather than
+        // computing an independent fraction of whatever width happens to
+        // be left in the row.
+        let field_w = 40.0 * self.ui_scale;
+        let label = "Movement speed (Humanlike only)";
 
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+        wrapping_field_row(
+            ui,
+            self,
+            |_state, ui| {
+                ui.label(label);
+            },
+            |state, ui| {
                 ui.label("px/s");
-                self.disable_if_busy(ui);
+                state.disable_if_busy(ui);
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.speed_max_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.speed_max_str)
+                        .desired_width(field_w)
                         .hint_text(MOUSE_TWEEN_SPEED_MAX_PX_S.to_string()),
                 );
 
                 ui.label("to");
                 ui.add(
-                    egui::TextEdit::singleline(&mut self.speed_min_str)
-                        .desired_width(40.0f32)
+                    egui::TextEdit::singleline(&mut state.speed_min_str)
+                        .desired_width(field_w)
                         .hint_text(MOUSE_TWEEN_SPEED_MIN_PX_S.to_string()),
                 );
-            });
-        });
+            },
+        );
     }
 
     pub fn show_infos(&self, ui: &mut egui::Ui, mouse: &MouseState, keys: &[Keycode]) {
@@ -54,20 +124,78 @@ impl RustyAutoClickerApp {
             .collect::<Vec<String>>();
         ui.label(format!("Mouse pressed: [{}]", buttons_pressed.join(", ")));
 
-        let key_txt = format!("Key pressed: {keys:?}");
+        let key_txt = format!(
+            "Key pressed: [{}]",
+            keys.iter().map(|k| crate::utils::abbreviate_keycode(*k)).collect::<Vec<_>>().join(", ")
+        );
         ui.label(key_txt);
     }
 
     pub fn show_autoclicker(&mut self, ui: &mut egui::Ui) {
+        // A SMALL, EQUAL amount of breathing room above AND below the
+        // buttons — just enough that they don't sit flush against the
+        // separator above or the bottom bar below. Rounded to a whole
+        // pixel — a fractional gap here was tripping egui's debug-only
+        // "Unaligned" warning overlay (dev/debug builds only; never shows
+        // up in a release build) at some window sizes.
+        //
+        // This is now the ONLY source of spacing on both sides — the
+        // fixed (unscaled) frame margins that `CentralPanel` and
+        // `show_bottombar`'s panel would otherwise add on top of this are
+        // zeroed out at their end (see the notes there), so this `gap`
+        // alone controls both, keeping them visually equal instead of the
+        // bottom stacking extra fixed margin on top of it.
+        let gap = (1.0 * self.ui_scale).round();
+        ui.add_space(gap);
         ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-            // Allocate a fixed-width region for the button pair so the centered
-            // parent layout centers the whole group (a plain `horizontal` would
-            // fill the full width and left-align its content).
-            let button_size = egui::vec2(120.0f32, 38.0f32);
-            let group_width = button_size.x * 2.0 + ui.spacing().item_spacing.x;
+            let autoclick_label = self.autoclick_button_label();
+            let hold_label = self.hold_button_label();
+
+            // Measure each label's actual rendered width so the button pair
+            // is sized to fit its content (a longer hotkey label such as
+            // "STOP (Num Lock)" just makes ITS button wider) rather than a
+            // fixed pixel size that clips long labels or leaves dead space
+            // around short ones. This is what used to require growing the
+            // whole OS window to compensate (`auto_resize_window`, removed) —
+            // now the buttons simply size themselves. Both the button's
+            // floor size and the font used to measure it scale by
+            // `self.ui_scale`, same as the rest of the UI — `TextStyle::
+            // Button.resolve(..)` on its own would ignore the global
+            // `override_font_id` scaling and measure against the
+            // (unscaled) default egui button font, undersizing the button
+            // relative to the text actually painted inside it.
+            let scale = self.ui_scale;
+            let button_height = 38.0 * scale;
+            let min_button_width = 100.0 * scale;
+            let padding = ui.spacing().button_padding;
+            let measure = |ui: &egui::Ui, text: &str| -> egui::Vec2 {
+                let font_id = ui
+                    .style()
+                    .override_font_id
+                    .clone()
+                    .unwrap_or_else(|| egui::TextStyle::Button.resolve(ui.style()));
+                let galley =
+                    ui.painter()
+                        .layout_no_wrap(text.to_owned(), font_id, egui::Color32::WHITE);
+                egui::vec2(
+                    (galley.size().x + padding.x * 2.0).max(min_button_width),
+                    button_height,
+                )
+            };
+            let autoclick_size = measure(ui, &autoclick_label);
+            let hold_size = measure(ui, &hold_label);
+
+            // Allocate a region exactly as wide as the two measured buttons
+            // (clamped to whatever space is actually available) so the
+            // centered parent layout centers the real content instead of a
+            // guessed fixed width.
+            let group_width =
+                (autoclick_size.x + hold_size.x + ui.spacing().item_spacing.x)
+                    .min(ui.available_width());
+            let group_height = autoclick_size.y.max(hold_size.y);
 
             ui.allocate_ui_with_layout(
-                egui::vec2(group_width, button_size.y),
+                egui::vec2(group_width, group_height),
                 egui::Layout::left_to_right(egui::Align::Center),
                 |ui| {
                     // Autoclick start/stop: disabled while holding or the hotkeys window is open
@@ -75,8 +203,8 @@ impl RustyAutoClickerApp {
                     if ui
                         .add_enabled(
                             autoclick_enabled,
-                            egui::widgets::Button::new(self.autoclick_button_label())
-                                .min_size(button_size),
+                            egui::widgets::Button::new(autoclick_label)
+                                .min_size(autoclick_size),
                         )
                         .clicked()
                     {
@@ -93,8 +221,7 @@ impl RustyAutoClickerApp {
                     if ui
                         .add_enabled(
                             hold_enabled,
-                            egui::widgets::Button::new(self.hold_button_label())
-                                .min_size(button_size),
+                            egui::widgets::Button::new(hold_label).min_size(hold_size),
                         )
                         .clicked()
                     {
@@ -107,5 +234,6 @@ impl RustyAutoClickerApp {
                 },
             );
         });
+        ui.add_space(gap);
     }
 }

--- a/src/gui/windows.rs
+++ b/src/gui/windows.rs
@@ -1,12 +1,22 @@
+use std::sync::Arc;
+
+use device_query::{Keycode, MouseState};
 use eframe::egui::{self, Context};
 
 use crate::{RustyAutoClickerApp, types::InteractionMode};
+
+/// Fixed size for the coordinate-picker viewport. This is intentionally
+/// hardcoded and NEVER changes at runtime — not by the user, not by any
+/// button, not by any setting. `.with_resizable(false)` below additionally
+/// makes it impossible for the user to drag-resize it even if they tried.
+const COORD_PICKER_SIZE: egui::Vec2 = egui::vec2(400.0, 65.0);
+const COORD_PICKER_CURSOR_OFFSET: egui::Vec2 = egui::vec2(16.0, 16.0);
 
 impl RustyAutoClickerApp {
     pub fn show_hotkeys_window(&mut self, ctx: &Context) {
         let idle = self.is_idle();
         egui::Window::new("Hotkeys")
-            .fixed_size(egui::vec2(260f32, 150f32))
+            .fixed_size(egui::vec2(260f32, 190f32))
             .anchor(egui::Align2::CENTER_CENTER, [0f32, 0f32])
             .collapsible(false)
             .open(&mut self.hotkey_window_open)
@@ -28,6 +38,31 @@ impl RustyAutoClickerApp {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                         ui.disable();
                         let text: String = if let Some(pressed_keys) = self.key_autoclick {
+                            format!("{:}", pressed_keys)
+                        } else {
+                            "PRESS ANY KEY".to_string()
+                        };
+                        ui.add_sized([130.0f32, 32.0f32], egui::widgets::Button::new(text));
+                    });
+                });
+                ui.horizontal(|ui| {
+                    if ui
+                        .add_sized(
+                            [120.0f32, 32.0f32],
+                            egui::widgets::Button::new("Set Coords"),
+                        )
+                        .on_hover_text("Opens the same coordinate picker as the \"Set Coords\" button")
+                        .clicked()
+                    {
+                        // Allow keybind only if app is not busy
+                        if idle {
+                            self.key_open_set_coord = None;
+                            self.mode = InteractionMode::SettingOpenCoordKey;
+                        }
+                    };
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                        ui.disable();
+                        let text: String = if let Some(pressed_keys) = self.key_open_set_coord {
                             format!("{:}", pressed_keys)
                         } else {
                             "PRESS ANY KEY".to_string()
@@ -85,5 +120,156 @@ impl RustyAutoClickerApp {
                     });
                 });
             });
+    }
+
+    /// Render the coordinate picker as its own independent, borderless egui
+    /// viewport that follows the mouse cursor.
+    ///
+    /// **Appearance (Issue #1 fix):** rebuilt to match the original v2.5.1
+    /// in-window overlay exactly — `egui::Panel::top` + `egui::MenuBar` +
+    /// `horizontal_wrapped` in a `right_to_left` layout, with the SAME
+    /// widget order 2.5.1 used: Y-edit, "Y", X-edit, "X", separator,
+    /// "Set with ..." label. No manual `Frame::fill(BLACK)` override — the
+    /// panel uses the app's normal dark-theme panel styling (set via
+    /// `picker_ctx.set_visuals(egui::Visuals::dark())` below), which is what
+    /// produced the near-black bar in 2.5.1 in the first place. This is
+    /// visually and structurally identical to the original, just hosted in
+    /// its own OS-level window instead of the main window's top panel.
+    ///
+    /// **Real-time X/Y (Issue #2 fix):** the previous version relied solely
+    /// on the PARENT calling `ctx.request_repaint_of(viewport_id)` once per
+    /// frame to nudge this viewport awake. That's a best-effort hint, not a
+    /// guarantee, and in practice the picker would paint once on creation
+    /// and then go dormant — frozen until the next F10 press recreated it.
+    /// The fix: the picker's own closure now also calls
+    /// `picker_ctx.request_repaint()` on itself every time it runs, the same
+    /// way the main window sustains its own loop via `ctx.request_repaint()`
+    /// in `gui/mod.rs`. This makes the picker a self-sustaining repaint loop
+    /// instead of depending on an external nudge, restoring true real-time
+    /// X/Y tracking with no added CPU cost (it's still one lightweight
+    /// repaint of a tiny single-row bar per frame, exactly like before).
+    pub fn show_coord_picker_viewport(&mut self, ctx: &Context, mouse: &MouseState, keys: &[Keycode]) {
+        let (mx, my) = mouse.coords;
+
+        // Publish this frame's data for the deferred viewport to read.
+        {
+            let mut shared = self.coord_picker_shared.lock().unwrap();
+            shared.pos = (mx, my);
+            shared.confirm_key = self.key_set_coord;
+        }
+
+        let target_pos = egui::pos2(mx as f32, my as f32) + COORD_PICKER_CURSOR_OFFSET;
+        let viewport_id = egui::ViewportId::from_hash_of("rusty_autoclicker_coord_picker");
+
+        // Request the repaint BEFORE (re-)registering the viewport this
+        // frame, not after. Ordering matters for deferred viewports: queuing
+        // the repaint first ensures it's honored on the same pass rather
+        // than potentially landing after this frame's viewport bookkeeping
+        // has already been finalized. This is one of a few redundant nudges
+        // below aimed at making the real-time X/Y update reliable — deferred
+        // viewports are a fairly new part of this eframe version, and relying
+        // on a single repaint call proved unreliable while the app is
+        // windowed (foreground), where the always-on-top main window appears
+        // to dominate the event loop's attention.
+        ctx.request_repaint_of(viewport_id);
+
+        // Always-on-top so the picker overlays whatever else is on screen —
+        // any other app's window, just like v2.5.1. This is now safe to
+        // enable: the main window auto-minimizes itself the moment picking
+        // starts (see `enter_coordinate_setting` in app.rs), so there is
+        // never a second always-on-top window visible at the same time to
+        // fight over z-order. `.with_resizable(false)` ensures the fixed
+        // 516x85 size can never be changed by the user, even by attempting
+        // to drag an edge.
+        let builder = egui::ViewportBuilder::default()
+            .with_inner_size(COORD_PICKER_SIZE)
+            .with_position(target_pos)
+            .with_decorations(false)
+            .with_resizable(false)
+            .with_always_on_top();
+
+        let shared = Arc::clone(&self.coord_picker_shared);
+        ctx.show_viewport_deferred(viewport_id, builder, move |picker_ctx, _class| {
+            // Match the main window's theme so the panel's fill color is
+            // identical to the original in-window overlay's background.
+            picker_ctx.set_visuals(egui::Visuals::dark());
+
+            let (pos, confirm_key) = {
+                let s = shared.lock().unwrap();
+                (s.pos, s.confirm_key)
+            };
+            let (mx, my) = pos;
+
+            // Reposition every frame unconditionally (no dedup). The earlier
+            // "only move if changed" optimization existed to avoid
+            // compositor churn from TWO always-on-top windows fighting for
+            // z-order; since only the main window is always-on-top now,
+            // that concern doesn't apply here, and always repositioning
+            // removes one more variable from the "why isn't this updating"
+            // question.
+            let target = egui::pos2(mx as f32, my as f32) + COORD_PICKER_CURSOR_OFFSET;
+            picker_ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(target));
+
+            let mut y_str = my.to_string();
+            let mut x_str = mx.to_string();
+
+            // Same container + widget order as the original v2.5.1 overlay:
+            // Panel::top -> MenuBar -> horizontal_wrapped -> right_to_left
+            // layout of [Y edit, "Y", X edit, "X", separator, "Set with..."].
+            egui::Panel::top("coord_picker_panel").show_inside(picker_ctx, |ui| {
+                egui::MenuBar::new().ui(ui, |ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                            ui.add(
+                                egui::TextEdit::singleline(&mut y_str)
+                                    .desired_width(50.0)
+                                    .hint_text("0"),
+                            );
+                            ui.label("Y");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut x_str)
+                                    .desired_width(50.0)
+                                    .hint_text("0"),
+                            );
+                            ui.label("X");
+                            ui.separator();
+                            let key_label = confirm_key
+                                .map(|k| k.to_string())
+                                .unwrap_or_else(|| "no key set".to_string());
+                            ui.label(format!(" Set with \"{key_label}\" / \"L Click\""));
+                        });
+                    });
+                });
+            });
+
+            // Keep this viewport repainting continuously on its OWN
+            // schedule. Two redundant calls here on purpose: `request_repaint`
+            // schedules the next frame ASAP, and `request_repaint_after` with
+            // a zero duration is a slightly different code path in some
+            // eframe versions. Belt-and-suspenders against the deferred-
+            // viewport repaint scheduling proving unreliable in this
+            // specific eframe version while the app is windowed.
+            picker_ctx.request_repaint();
+            picker_ctx.request_repaint_after(std::time::Duration::ZERO);
+        });
+
+        // Nudge again from the parent after registration too, in addition to
+        // the nudge sent before `show_viewport_deferred` above.
+        ctx.request_repaint_of(viewport_id);
+
+        // Confirmation detection stays here in `logic()`, driven by the
+        // same global device-state poll used everywhere else in the app —
+        // it does not depend on the picker viewport having painted at all,
+        // so it keeps working even while minimized.
+        let confirm_key_down = self.key_set_coord.is_some_and(|k| keys.contains(&k));
+        // device_query's mouse.button_pressed is 1-indexed; index 1 = Left click.
+        let confirm_click = mouse.button_pressed.get(1).copied().unwrap_or(false);
+
+        self.click_x_str = mx.to_string();
+        self.click_y_str = my.to_string();
+
+        if confirm_click || confirm_key_down {
+            self.exit_coordinate_setting(ctx);
+        }
     }
 }

--- a/src/gui/windows.rs
+++ b/src/gui/windows.rs
@@ -10,7 +10,33 @@ use crate::{RustyAutoClickerApp, types::InteractionMode};
 /// button, not by any setting. `.with_resizable(false)` below additionally
 /// makes it impossible for the user to drag-resize it even if they tried.
 const COORD_PICKER_SIZE: egui::Vec2 = egui::vec2(400.0, 65.0);
-const COORD_PICKER_CURSOR_OFFSET: egui::Vec2 = egui::vec2(16.0, 16.0);
+/// Vertical gap between the cursor tip and the top of the picker window.
+/// Horizontally the picker is centered under the cursor instead of offset
+/// to the side — see `clamped_picker_pos` below for why this alone isn't
+/// enough to keep it fully on-screen.
+const COORD_PICKER_VERTICAL_GAP: f32 = 16.0;
+
+/// Compute where the picker window should sit for a given (logical) cursor
+/// position: horizontally centered under the cursor, `COORD_PICKER_VERTICAL_GAP`
+/// below it (so the cursor never overlaps the window), then clamped to stay
+/// fully within the current monitor so it can't get cut off against the
+/// right/bottom edge the way a fixed offset could.
+///
+/// Note: `ViewportInfo::monitor_size` only gives the monitor's *size*, not
+/// its origin, so this assumes the monitor's origin is (0, 0) — correct for
+/// the primary monitor / single-monitor setups. On a multi-monitor layout
+/// where the picker is on a secondary monitor positioned to the left of or
+/// above the primary, the clamp can be slightly off; a real fix needs
+/// per-monitor origin info egui doesn't currently expose here.
+fn clamped_picker_pos(monitor_size: Option<egui::Vec2>, cursor: egui::Pos2) -> egui::Pos2 {
+    let mut x = cursor.x - COORD_PICKER_SIZE.x / 2.0;
+    let mut y = cursor.y + COORD_PICKER_VERTICAL_GAP;
+    if let Some(size) = monitor_size {
+        x = x.clamp(0.0, (size.x - COORD_PICKER_SIZE.x).max(0.0));
+        y = y.clamp(0.0, (size.y - COORD_PICKER_SIZE.y).max(0.0));
+    }
+    egui::pos2(x, y)
+}
 
 impl RustyAutoClickerApp {
     pub fn show_hotkeys_window(&mut self, ctx: &Context) {
@@ -38,7 +64,7 @@ impl RustyAutoClickerApp {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                         ui.disable();
                         let text: String = if let Some(pressed_keys) = self.key_autoclick {
-                            format!("{:}", pressed_keys)
+                            crate::utils::abbreviate_keycode(pressed_keys).to_string()
                         } else {
                             "PRESS ANY KEY".to_string()
                         };
@@ -63,7 +89,7 @@ impl RustyAutoClickerApp {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                         ui.disable();
                         let text: String = if let Some(pressed_keys) = self.key_open_set_coord {
-                            format!("{:}", pressed_keys)
+                            crate::utils::abbreviate_keycode(pressed_keys).to_string()
                         } else {
                             "PRESS ANY KEY".to_string()
                         };
@@ -88,7 +114,7 @@ impl RustyAutoClickerApp {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                         ui.disable();
                         let text: String = if let Some(pressed_keys) = self.key_set_coord {
-                            format!("{:} / L Click", pressed_keys)
+                            format!("{} / L Click", crate::utils::abbreviate_keycode(pressed_keys))
                         } else {
                             "PRESS ANY KEY".to_string()
                         };
@@ -112,7 +138,7 @@ impl RustyAutoClickerApp {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                         ui.disable();
                         let text: String = if let Some(pressed_keys) = self.key_hold {
-                            format!("{:}", pressed_keys)
+                            crate::utils::abbreviate_keycode(pressed_keys).to_string()
                         } else {
                             "PRESS ANY KEY".to_string()
                         };
@@ -158,7 +184,17 @@ impl RustyAutoClickerApp {
             shared.confirm_key = self.key_set_coord;
         }
 
-        let target_pos = egui::pos2(mx as f32, my as f32) + COORD_PICKER_CURSOR_OFFSET;
+        // `device_query` reports mouse coords in PHYSICAL screen pixels, but
+        // egui's viewport positioning APIs (`with_position`,
+        // `ViewportCommand::OuterPosition`) expect LOGICAL points. On any
+        // display scale other than 100% these are not the same number, and
+        // the picker drifts further from the real cursor the further it is
+        // from the monitor's origin. Divide by `pixels_per_point()` to
+        // convert physical -> logical before positioning.
+        let ppp = ctx.pixels_per_point();
+        let cursor_logical = egui::pos2(mx as f32 / ppp, my as f32 / ppp);
+        let monitor_size = ctx.input(|i| i.viewport().monitor_size);
+        let target_pos = clamped_picker_pos(monitor_size, cursor_logical);
         let viewport_id = egui::ViewportId::from_hash_of("rusty_autoclicker_coord_picker");
 
         // Request the repaint BEFORE (re-)registering the viewport this
@@ -207,7 +243,15 @@ impl RustyAutoClickerApp {
             // that concern doesn't apply here, and always repositioning
             // removes one more variable from the "why isn't this updating"
             // question.
-            let target = egui::pos2(mx as f32, my as f32) + COORD_PICKER_CURSOR_OFFSET;
+            // Same physical -> logical conversion as the parent side above.
+            // Use THIS viewport's own `pixels_per_point()`, not the root's —
+            // if the picker is dragged onto a monitor with a different scale
+            // factor than the main window's monitor, the two can legitimately
+            // differ.
+            let picker_ppp = picker_ctx.pixels_per_point();
+            let cursor_logical = egui::pos2(mx as f32 / picker_ppp, my as f32 / picker_ppp);
+            let monitor_size = picker_ctx.input(|i| i.viewport().monitor_size);
+            let target = clamped_picker_pos(monitor_size, cursor_logical);
             picker_ctx.send_viewport_cmd(egui::ViewportCommand::OuterPosition(target));
 
             let mut y_str = my.to_string();
@@ -234,7 +278,7 @@ impl RustyAutoClickerApp {
                             ui.label("X");
                             ui.separator();
                             let key_label = confirm_key
-                                .map(|k| k.to_string())
+                                .map(|k| crate::utils::abbreviate_keycode(k).to_string())
                                 .unwrap_or_else(|| "no key set".to_string());
                             ui.label(format!(" Set with \"{key_label}\" / \"L Click\""));
                         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,52 @@
 #![forbid(unsafe_code)]
-#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
+#![cfg_attr(not(debug_assertions), deny(warnings))]
 #![warn(clippy::all, rust_2018_idioms)]
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] //Hide console window in release builds on Windows, this blocks stdout.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use eframe::egui;
 
 mod app;
 mod defines;
 mod gui;
+mod settings;
 mod types;
 mod utils;
 
 use crate::{
     app::RustyAutoClickerApp,
-    defines::{APP_NAME, WINDOW_HEIGHT, WINDOW_WIDTH},
+    defines::{APP_NAME, WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y, WINDOW_HEIGHT, WINDOW_WIDTH},
+    settings::load_settings,
     utils::load_icon,
 };
 
-// When compiling natively
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
     use eframe::egui::ViewportBuilder;
+
+    // Read the saved position before constructing NativeOptions so the OS can
+    // place the window at the correct location from the very first frame —
+    // eliminating the "flash at default pos → jump to saved pos" flicker.
+    let saved = load_settings();
+    let start_pos = saved
+        .as_ref()
+        .and_then(|s| s.window_position)
+        .map(|[x, y]| egui::pos2(x, y))
+        .unwrap_or_else(|| egui::pos2(WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y));
+    let start_size = saved
+        .as_ref()
+        .and_then(|s| s.window_size)
+        .map(|[w, h]| egui::vec2(w, h))
+        .unwrap_or_else(|| egui::vec2(WINDOW_WIDTH, WINDOW_HEIGHT));
 
     let native_options = eframe::NativeOptions {
         renderer: eframe::Renderer::Wgpu,
         viewport: ViewportBuilder::default()
             .with_always_on_top()
             .with_decorations(true)
-            .with_inner_size(egui::vec2(WINDOW_WIDTH, WINDOW_HEIGHT))
+            // Start at the saved size — no flicker
+            .with_inner_size(start_size)
+            // Start at the saved position — no flicker
+            .with_position(start_pos)
             .with_resizable(true)
             .with_transparent(true)
             .with_icon(load_icon()),
@@ -49,8 +68,8 @@ fn main() {
                 "{e}\n\n\
                 Rusty AutoClicker could not start due to a graphics initialization error.\n\n\
                 Please ensure your system has a compatible graphics driver installed and supports Vulkan, Metal or DirectX 12.\n\n\
-                If the problem persists, try updating your graphics drivers or running the application on a different machine.")
-            )
+                If the problem persists, try updating your graphics drivers or running the application on a different machine."
+            ))
             .alert()
             .show()
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@ mod utils;
 
 use crate::{
     app::RustyAutoClickerApp,
-    defines::{APP_NAME, WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y, WINDOW_HEIGHT, WINDOW_WIDTH},
+    defines::{
+        APP_NAME, WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y, WINDOW_HEIGHT, WINDOW_MIN_HEIGHT,
+        WINDOW_MIN_WIDTH, WINDOW_WIDTH,
+    },
     settings::load_settings,
     utils::load_icon,
 };
@@ -32,19 +35,32 @@ fn main() {
         .and_then(|s| s.window_position)
         .map(|[x, y]| egui::pos2(x, y))
         .unwrap_or_else(|| egui::pos2(WINDOW_DEFAULT_X, WINDOW_DEFAULT_Y));
+    // Clamp to the minimum here too, before the OS window is even created —
+    // `app.rs::new()` clamps again once the app has an `egui::Context` to
+    // work with, but a degenerate saved size should never reach
+    // `with_inner_size` in the first place either.
     let start_size = saved
         .as_ref()
         .and_then(|s| s.window_size)
-        .map(|[w, h]| egui::vec2(w, h))
+        .map(|[w, h]| egui::vec2(w.max(WINDOW_MIN_WIDTH), h.max(WINDOW_MIN_HEIGHT)))
         .unwrap_or_else(|| egui::vec2(WINDOW_WIDTH, WINDOW_HEIGHT));
 
     let native_options = eframe::NativeOptions {
         renderer: eframe::Renderer::Wgpu,
         viewport: ViewportBuilder::default()
-            .with_always_on_top()
+            // Deliberately NOT always-on-top for the main window — it
+            // should behave like a normal window (can be covered by other
+            // windows, brought back via the taskbar, etc). The coordinate
+            // picker's OWN always-on-top, in `gui/windows.rs`, is separate
+            // and stays as-is: it genuinely needs to stay visible/clickable
+            // above whatever window you're picking coordinates from.
             .with_decorations(true)
             // Start at the saved size — no flicker
             .with_inner_size(start_size)
+            // Enforced floor: small enough to stay flexible, large enough
+            // that the window controls plus one full row of the most
+            // important controls (Click Interval) always stay usable.
+            .with_min_inner_size(egui::vec2(WINDOW_MIN_WIDTH, WINDOW_MIN_HEIGHT))
             // Start at the saved position — no flicker
             .with_position(start_pos)
             .with_resizable(true)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,214 @@
+use std::{fs, path::PathBuf};
+
+use device_query::Keycode;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app::RustyAutoClickerApp,
+    types::{AppMode, ClickButton, ClickPosition, ClickType},
+};
+
+const SETTINGS_DIR_NAME: &str = "rusty-autoclicker";
+const SETTINGS_FILE_NAME: &str = "settings.json";
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct Settings {
+    // Timing
+    pub hr_str: String,
+    pub min_str: String,
+    pub sec_str: String,
+    pub ms_str: String,
+
+    // Click amount
+    pub click_amount_str: String,
+
+    // Click coordinates (0,0 by default — separate from window position)
+    pub click_x_str: String,
+    pub click_y_str: String,
+
+    // Tween speed
+    pub speed_min_str: String,
+    pub speed_max_str: String,
+
+    // Hotkeys
+    pub key_autoclick: Option<String>,
+    pub key_open_set_coord: Option<String>,
+    pub key_set_coord: Option<String>,
+    pub key_hold: Option<String>,
+
+    // UI-controlled enums
+    pub click_btn: String,
+    pub click_type: String,
+    pub click_position: String,
+    pub app_mode: String,
+
+    /// Window inner size [width, height] in logical pixels.
+    /// Auto-saved on close; not affected by the Save/Reset buttons.
+    pub window_size: Option<[f32; 2]>,
+
+    /// Window outer position [x, y] in logical pixels.
+    /// Saved by the Save button and on close; Reset returns to default position.
+    pub window_position: Option<[f32; 2]>,
+}
+
+impl Settings {
+    pub fn from_app(app: &RustyAutoClickerApp) -> Self {
+        Self {
+            hr_str: app.hr_str.clone(),
+            min_str: app.min_str.clone(),
+            sec_str: app.sec_str.clone(),
+            ms_str: app.ms_str.clone(),
+
+            click_amount_str: app.click_amount_str.clone(),
+
+            click_x_str: app.click_x_str.clone(),
+            click_y_str: app.click_y_str.clone(),
+
+            speed_min_str: app.speed_min_str.clone(),
+            speed_max_str: app.speed_max_str.clone(),
+
+            key_autoclick: app.key_autoclick.map(|k| k.to_string()),
+            key_open_set_coord: app.key_open_set_coord.map(|k| k.to_string()),
+            key_set_coord: app.key_set_coord.map(|k| k.to_string()),
+            key_hold: app.key_hold.map(|k| k.to_string()),
+
+            click_btn: app.click_btn.to_setting_string(),
+            click_type: click_type_to_str(app.click_type).to_owned(),
+            click_position: click_position_to_str(app.click_position).to_owned(),
+            app_mode: app_mode_to_str(app.app_mode).to_owned(),
+
+            window_size: Some(app.last_window_size),
+            window_position: Some([app.last_window_pos.x, app.last_window_pos.y]),
+        }
+    }
+
+    /// Apply this snapshot onto an app instance.
+    /// window_size and window_position are handled separately in `new()`.
+    pub fn apply_to(&self, app: &mut RustyAutoClickerApp) {
+        app.hr_str = self.hr_str.clone();
+        app.min_str = self.min_str.clone();
+        app.sec_str = self.sec_str.clone();
+        app.ms_str = self.ms_str.clone();
+
+        app.click_amount_str = self.click_amount_str.clone();
+
+        app.click_x_str = self.click_x_str.clone();
+        app.click_y_str = self.click_y_str.clone();
+
+        app.speed_min_str = self.speed_min_str.clone();
+        app.speed_max_str = self.speed_max_str.clone();
+
+        app.key_autoclick = parse_keycode(self.key_autoclick.as_deref());
+        app.key_open_set_coord = parse_keycode(self.key_open_set_coord.as_deref());
+        app.key_set_coord = parse_keycode(self.key_set_coord.as_deref());
+        app.key_hold = parse_keycode(self.key_hold.as_deref());
+
+        if let Some(click_btn) = ClickButton::from_setting_string(&self.click_btn) {
+            app.click_btn = click_btn;
+        }
+        app.click_type = str_to_click_type(&self.click_type).unwrap_or(app.click_type);
+        app.click_position =
+            str_to_click_position(&self.click_position).unwrap_or(app.click_position);
+        app.app_mode = str_to_app_mode(&self.app_mode).unwrap_or(app.app_mode);
+    }
+}
+
+// ---------- helpers --------------------------------------------------------
+
+fn parse_keycode(s: Option<&str>) -> Option<Keycode> {
+    s.and_then(|s| s.parse::<Keycode>().ok())
+}
+
+fn click_type_to_str(t: ClickType) -> &'static str {
+    match t { ClickType::Single => "Single", ClickType::Double => "Double" }
+}
+fn str_to_click_type(s: &str) -> Option<ClickType> {
+    match s { "Single" => Some(ClickType::Single), "Double" => Some(ClickType::Double), _ => None }
+}
+
+fn click_position_to_str(p: ClickPosition) -> &'static str {
+    match p { ClickPosition::Mouse => "Mouse", ClickPosition::Coord => "Coord" }
+}
+fn str_to_click_position(s: &str) -> Option<ClickPosition> {
+    match s { "Mouse" => Some(ClickPosition::Mouse), "Coord" => Some(ClickPosition::Coord), _ => None }
+}
+
+fn app_mode_to_str(m: AppMode) -> &'static str {
+    match m { AppMode::Bot => "Bot", AppMode::Humanlike => "Humanlike" }
+}
+fn str_to_app_mode(s: &str) -> Option<AppMode> {
+    match s { "Bot" => Some(AppMode::Bot), "Humanlike" => Some(AppMode::Humanlike), _ => None }
+}
+
+// ---------- I/O ------------------------------------------------------------
+
+fn settings_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join(SETTINGS_DIR_NAME))
+}
+
+fn settings_path() -> Option<PathBuf> {
+    settings_dir().map(|d| d.join(SETTINGS_FILE_NAME))
+}
+
+pub fn load_settings() -> Option<Settings> {
+    let data = fs::read_to_string(settings_path()?).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Write all settings to disk (called by Save button, Reset, and Drop).
+pub fn save_settings(settings: &Settings) {
+    let Some(dir) = settings_dir() else { return };
+    if fs::create_dir_all(&dir).is_err() { return }
+    let Some(path) = settings_path() else { return };
+    if let Ok(json) = serde_json::to_string_pretty(settings) {
+        let _ = fs::write(path, json);
+    }
+}
+
+/// Targeted patch: update ONLY window_size and window_position in the JSON
+/// on disk without touching anything else. Called from Drop so unsaved
+/// user settings are never overwritten by the window-geometry auto-save.
+pub fn save_window_geometry(width: f32, height: f32, pos_x: f32, pos_y: f32) {
+    let Some(dir) = settings_dir() else { return };
+    if fs::create_dir_all(&dir).is_err() { return }
+    let Some(path) = settings_path() else { return };
+
+    let mut value: serde_json::Value = fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("window_size".to_string(), serde_json::json!([width, height]));
+        obj.insert("window_position".to_string(), serde_json::json!([pos_x, pos_y]));
+    }
+
+    if let Ok(json) = serde_json::to_string_pretty(&value) {
+        let _ = fs::write(path, json);
+    }
+}
+
+// ---------- tests ----------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn click_type_round_trips() {
+        assert_eq!(str_to_click_type(click_type_to_str(ClickType::Single)), Some(ClickType::Single));
+        assert_eq!(str_to_click_type(click_type_to_str(ClickType::Double)), Some(ClickType::Double));
+    }
+
+    #[test]
+    fn click_position_round_trips() {
+        assert_eq!(str_to_click_position(click_position_to_str(ClickPosition::Mouse)), Some(ClickPosition::Mouse));
+        assert_eq!(str_to_click_position(click_position_to_str(ClickPosition::Coord)), Some(ClickPosition::Coord));
+    }
+
+    #[test]
+    fn app_mode_round_trips() {
+        assert_eq!(str_to_app_mode(app_mode_to_str(AppMode::Bot)), Some(AppMode::Bot));
+        assert_eq!(str_to_app_mode(app_mode_to_str(AppMode::Humanlike)), Some(AppMode::Humanlike));
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,6 +30,15 @@ pub struct Settings {
     pub speed_min_str: String,
     pub speed_max_str: String,
 
+    // Random offset (+/- jitter on the click interval). `#[serde(default)]`
+    // on both so settings.json files saved by older versions (which don't
+    // have these keys at all) still deserialize instead of failing to load
+    // entirely.
+    #[serde(default)]
+    pub random_offset_enabled: bool,
+    #[serde(default = "default_random_offset_str")]
+    pub random_offset_str: String,
+
     // Hotkeys
     pub key_autoclick: Option<String>,
     pub key_open_set_coord: Option<String>,
@@ -41,6 +50,15 @@ pub struct Settings {
     pub click_type: String,
     pub click_position: String,
     pub app_mode: String,
+
+    /// The last keyboard key selected in Keyboard mode, remembered
+    /// independently of `click_btn` (which may currently be Mouse mode).
+    /// Reused so Mouse -> Keyboard restores this instead of resetting to
+    /// Space. Persisted using the same `ClickButton::Key(..)` string form
+    /// as `click_btn` above, purely for convenience (reuses
+    /// `to_setting_string`/`from_setting_string` rather than needing a
+    /// separate key-only serialization helper).
+    pub last_keyboard_key: String,
 
     /// Window inner size [width, height] in logical pixels.
     /// Auto-saved on close; not affected by the Save/Reset buttons.
@@ -67,6 +85,9 @@ impl Settings {
             speed_min_str: app.speed_min_str.clone(),
             speed_max_str: app.speed_max_str.clone(),
 
+            random_offset_enabled: app.random_offset_enabled,
+            random_offset_str: app.random_offset_str.clone(),
+
             key_autoclick: app.key_autoclick.map(|k| k.to_string()),
             key_open_set_coord: app.key_open_set_coord.map(|k| k.to_string()),
             key_set_coord: app.key_set_coord.map(|k| k.to_string()),
@@ -76,6 +97,7 @@ impl Settings {
             click_type: click_type_to_str(app.click_type).to_owned(),
             click_position: click_position_to_str(app.click_position).to_owned(),
             app_mode: app_mode_to_str(app.app_mode).to_owned(),
+            last_keyboard_key: ClickButton::Key(app.last_keyboard_key).to_setting_string(),
 
             window_size: Some(app.last_window_size),
             window_position: Some([app.last_window_pos.x, app.last_window_pos.y]),
@@ -98,6 +120,9 @@ impl Settings {
         app.speed_min_str = self.speed_min_str.clone();
         app.speed_max_str = self.speed_max_str.clone();
 
+        app.random_offset_enabled = self.random_offset_enabled;
+        app.random_offset_str = self.random_offset_str.clone();
+
         app.key_autoclick = parse_keycode(self.key_autoclick.as_deref());
         app.key_open_set_coord = parse_keycode(self.key_open_set_coord.as_deref());
         app.key_set_coord = parse_keycode(self.key_set_coord.as_deref());
@@ -110,10 +135,18 @@ impl Settings {
         app.click_position =
             str_to_click_position(&self.click_position).unwrap_or(app.click_position);
         app.app_mode = str_to_app_mode(&self.app_mode).unwrap_or(app.app_mode);
+
+        if let Some(ClickButton::Key(k)) = ClickButton::from_setting_string(&self.last_keyboard_key) {
+            app.last_keyboard_key = k;
+        }
     }
 }
 
 // ---------- helpers --------------------------------------------------------
+
+fn default_random_offset_str() -> String {
+    crate::defines::DEFAULT_RANDOM_OFFSET_STR.to_owned()
+}
 
 fn parse_keycode(s: Option<&str>) -> Option<Keycode> {
     s.and_then(|s| s.parse::<Keycode>().ok())

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,7 @@ pub enum InteractionMode {
     Holding,
     SettingCoord,
     SettingAutoclickKey,
+    SettingOpenCoordKey,
     SettingSetCoordKey,
     SettingHoldKey,
 }
@@ -65,6 +66,99 @@ impl fmt::Display for ClickButton {
         }
     }
 }
+
+impl ClickButton {
+    /// Stable, persistence-friendly string form, e.g. `"mouse:Left"` or
+    /// `"key:KeyA"`. Neither `rdev::Button` nor `rdev::Key` implement
+    /// `serde` traits, so settings persistence round-trips through this
+    /// instead of deriving `Serialize`/`Deserialize` directly on
+    /// [`ClickButton`].
+    pub fn to_setting_string(self) -> String {
+        match self {
+            ClickButton::Mouse(button) => format!("mouse:{}", mouse_button_name(button)),
+            ClickButton::Key(key) => format!("key:{}", key_name(key)),
+        }
+    }
+
+    /// Parse the string form produced by [`Self::to_setting_string`].
+    /// Returns `None` for anything unrecognized (e.g. a settings file from
+    /// an incompatible version), so callers can fall back to a default.
+    pub fn from_setting_string(s: &str) -> Option<Self> {
+        let (kind, value) = s.split_once(':')?;
+        match kind {
+            "mouse" => mouse_button_from_name(value).map(ClickButton::Mouse),
+            "key" => key_from_name(value).map(ClickButton::Key),
+            _ => None,
+        }
+    }
+}
+
+fn mouse_button_name(button: Button) -> &'static str {
+    match button {
+        Button::Left => "Left",
+        Button::Right => "Right",
+        Button::Middle => "Middle",
+        // rdev::Button has a non-exhaustive `Unknown(u8)` variant that the UI
+        // never selects; fall back to Left rather than failing to persist.
+        _ => "Left",
+    }
+}
+
+fn mouse_button_from_name(s: &str) -> Option<Button> {
+    match s {
+        "Left" => Some(Button::Left),
+        "Right" => Some(Button::Right),
+        "Middle" => Some(Button::Middle),
+        _ => None,
+    }
+}
+
+/// Generates `key_name`/`key_from_name` covering exactly the `rdev::Key`
+/// variants offered in the keyboard-button dropdown
+/// (`gui/sections/buttons.rs`), so the persisted string always matches a
+/// selectable value.
+macro_rules! key_names {
+    ($($variant:ident),* $(,)?) => {
+        fn key_name(key: Key) -> &'static str {
+            match key {
+                $(Key::$variant => stringify!($variant),)*
+                // Variants outside the dropdown's selectable set; persisting
+                // these can't happen via the UI, but keep this exhaustive.
+                _ => "Space",
+            }
+        }
+
+        fn key_from_name(s: &str) -> Option<Key> {
+            match s {
+                $(stringify!($variant) => Some(Key::$variant),)*
+                _ => None,
+            }
+        }
+    };
+}
+
+key_names!(
+    // Modifier keys
+    Alt, AltGr, CapsLock, ControlLeft, ControlRight, MetaLeft, MetaRight, ShiftLeft, ShiftRight,
+    Function,
+    // Navigation
+    UpArrow, DownArrow, LeftArrow, RightArrow, Home, End, PageUp, PageDown, Insert, Delete,
+    Escape, Return, Tab, Space,
+    // Function keys
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+    // Print/Lock
+    PrintScreen, ScrollLock, Pause, NumLock,
+    // Top row number keys and symbols
+    BackQuote, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9, Num0, Minus, Equal,
+    // Letter keys
+    KeyA, KeyB, KeyC, KeyD, KeyE, KeyF, KeyG, KeyH, KeyI, KeyJ, KeyK, KeyL, KeyM, KeyN, KeyO,
+    KeyP, KeyQ, KeyR, KeyS, KeyT, KeyU, KeyV, KeyW, KeyX, KeyY, KeyZ,
+    // Punctuation and symbol keys
+    LeftBracket, RightBracket, SemiColon, Quote, BackSlash, IntlBackslash, Comma, Dot, Slash,
+    // Keypad
+    KpReturn, KpMinus, KpPlus, KpMultiply, KpDivide, Kp0, Kp1, Kp2, Kp3, Kp4, Kp5, Kp6, Kp7, Kp8,
+    Kp9, KpDelete,
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,7 @@ pub enum InteractionMode {
     SettingOpenCoordKey,
     SettingSetCoordKey,
     SettingHoldKey,
+    SettingClickKey,
 }
 
 #[derive(PartialEq, Copy, Clone)]
@@ -62,7 +63,7 @@ impl fmt::Display for ClickButton {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ClickButton::Mouse(button) => write!(f, "{button:?}"),
-            ClickButton::Key(key) => write!(f, "{key:?}"),
+            ClickButton::Key(key) => write!(f, "{}", crate::utils::abbreviate_key(*key)),
         }
     }
 }
@@ -143,6 +144,7 @@ key_names!(
     Function,
     // Navigation
     UpArrow, DownArrow, LeftArrow, RightArrow, Home, End, PageUp, PageDown, Insert, Delete,
+    Backspace,
     Escape, Return, Tab, Space,
     // Function keys
     F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,9 @@
 use std::{env, thread, time::Duration};
 
+use device_query::Keycode;
 use eframe::emath::Numeric;
 use rand::{RngExt, prelude::ThreadRng};
-use rdev::{EventType, SimulateError, simulate};
+use rdev::{EventType, Key, SimulateError, simulate};
 use sanitizer::prelude::StringSanitizer;
 
 use crate::{
@@ -15,6 +16,326 @@ use crate::{
     },
     types::{AppMode, ClickButton, ClickInfo, ClickPosition},
 };
+
+/// Abbreviated, ≤8-character display form of an `rdev::Key`, for compact
+/// display in the click-button dropdown, capture feedback/error messages,
+/// and anywhere else a click-button key is shown. This is the single
+/// source of truth for that formatting — don't use `{:?}` / `stringify!`
+/// on `Key` directly, or the dropdown and the hotkey bar will drift apart
+/// again (which is the whole reason this exists: "KeyF" in the dropdown vs
+/// "F" in the hotkey bar for what is conceptually the same key).
+///
+/// Kept in sync 1:1 with `abbreviate_keycode` below for every key that
+/// exists in both enums, so e.g. the F key always reads "F" whether it
+/// came from a hotkey capture or the click-button dropdown.
+pub fn abbreviate_key(key: Key) -> &'static str {
+    use Key as K;
+    match key {
+        K::KeyA => "A", K::KeyB => "B", K::KeyC => "C", K::KeyD => "D", K::KeyE => "E",
+        K::KeyF => "F", K::KeyG => "G", K::KeyH => "H", K::KeyI => "I", K::KeyJ => "J",
+        K::KeyK => "K", K::KeyL => "L", K::KeyM => "M", K::KeyN => "N", K::KeyO => "O",
+        K::KeyP => "P", K::KeyQ => "Q", K::KeyR => "R", K::KeyS => "S", K::KeyT => "T",
+        K::KeyU => "U", K::KeyV => "V", K::KeyW => "W", K::KeyX => "X", K::KeyY => "Y",
+        K::KeyZ => "Z",
+
+        K::Num0 => "0", K::Num1 => "1", K::Num2 => "2", K::Num3 => "3", K::Num4 => "4",
+        K::Num5 => "5", K::Num6 => "6", K::Num7 => "7", K::Num8 => "8", K::Num9 => "9",
+
+        K::F1 => "F1", K::F2 => "F2", K::F3 => "F3", K::F4 => "F4", K::F5 => "F5",
+        K::F6 => "F6", K::F7 => "F7", K::F8 => "F8", K::F9 => "F9", K::F10 => "F10",
+        K::F11 => "F11", K::F12 => "F12",
+
+        K::Escape => "Escape",
+        K::Space => "Space",
+
+        K::ControlLeft => "LCtrl",
+        K::ControlRight => "RCtrl",
+        K::ShiftLeft => "LShift",
+        K::ShiftRight => "RShift",
+        K::Alt => "Alt",
+        K::AltGr => "AltGr",
+        K::MetaLeft => "LMeta",
+        K::MetaRight => "RMeta",
+        K::Function => "Fn",
+
+        K::Return => "Enter",
+        K::UpArrow => "Up",
+        K::DownArrow => "Down",
+        K::LeftArrow => "Left",
+        K::RightArrow => "Right",
+
+        K::CapsLock => "CapsLock",
+        K::Tab => "Tab",
+        K::Home => "Home",
+        K::End => "End",
+        K::PageUp => "PageUp",
+        K::PageDown => "PageDown",
+        K::Insert => "Insert",
+        K::Delete => "Delete",
+        K::Backspace => "Backspc",
+
+        K::PrintScreen => "PrtSc",
+        K::ScrollLock => "ScrLk",
+        K::Pause => "Pause",
+        K::NumLock => "NumLock",
+
+        K::BackQuote => "`",
+        K::Minus => "-",
+        K::Equal => "=",
+        K::LeftBracket => "[",
+        K::RightBracket => "]",
+        K::SemiColon => ";",
+        K::Quote => "'",
+        K::BackSlash => "\\",
+        K::IntlBackslash => "IntlBS",
+        K::Comma => ",",
+        K::Dot => ".",
+        K::Slash => "/",
+
+        K::KpReturn => "NumEnt",
+        K::KpMinus => "Num-",
+        K::KpPlus => "Num+",
+        K::KpMultiply => "Num*",
+        K::KpDivide => "Num/",
+        K::Kp0 => "Num0", K::Kp1 => "Num1", K::Kp2 => "Num2", K::Kp3 => "Num3",
+        K::Kp4 => "Num4", K::Kp5 => "Num5", K::Kp6 => "Num6", K::Kp7 => "Num7",
+        K::Kp8 => "Num8", K::Kp9 => "Num9",
+        K::KpDelete => "Num.",
+
+        // Anything outside the dropdown's selectable set (click_btn can
+        // only ever hold a value the UI let the user pick).
+        _ => "?",
+    }
+}
+
+/// Abbreviated, ≤8-character display form of a `device_query::Keycode`,
+/// for the top hotkey bar and the Hotkeys window. Kept 1:1 in sync with
+/// `abbreviate_key` above for every key both enums share — see that
+/// function's doc comment for why this matters.
+///
+/// Unlike `abbreviate_key`, this is exhaustive over every `Keycode`
+/// variant rather than falling back to a placeholder, since a hotkey field
+/// can genuinely hold any of them (including ones with no dropdown/rdev
+/// counterpart, like F13-F20 or the Mac Command/Option keys).
+pub fn abbreviate_keycode(keycode: Keycode) -> &'static str {
+    use Keycode as K;
+    match keycode {
+        K::Key0 => "0", K::Key1 => "1", K::Key2 => "2", K::Key3 => "3", K::Key4 => "4",
+        K::Key5 => "5", K::Key6 => "6", K::Key7 => "7", K::Key8 => "8", K::Key9 => "9",
+
+        K::A => "A", K::B => "B", K::C => "C", K::D => "D", K::E => "E", K::F => "F",
+        K::G => "G", K::H => "H", K::I => "I", K::J => "J", K::K => "K", K::L => "L",
+        K::M => "M", K::N => "N", K::O => "O", K::P => "P", K::Q => "Q", K::R => "R",
+        K::S => "S", K::T => "T", K::U => "U", K::V => "V", K::W => "W", K::X => "X",
+        K::Y => "Y", K::Z => "Z",
+
+        K::F1 => "F1", K::F2 => "F2", K::F3 => "F3", K::F4 => "F4", K::F5 => "F5",
+        K::F6 => "F6", K::F7 => "F7", K::F8 => "F8", K::F9 => "F9", K::F10 => "F10",
+        K::F11 => "F11", K::F12 => "F12", K::F13 => "F13", K::F14 => "F14",
+        K::F15 => "F15", K::F16 => "F16", K::F17 => "F17", K::F18 => "F18",
+        K::F19 => "F19", K::F20 => "F20",
+
+        K::Escape => "Escape",
+        K::Space => "Space",
+
+        K::LControl => "LCtrl",
+        K::RControl => "RCtrl",
+        K::LShift => "LShift",
+        K::RShift => "RShift",
+        K::LAlt => "Alt",
+        K::RAlt => "AltGr",
+        // Mac-only, no rdev/dropdown counterpart.
+        K::Command => "Cmd",
+        K::RCommand => "RCmd",
+        K::LOption => "LOpt",
+        K::ROption => "ROpt",
+        K::LMeta => "LMeta",
+        K::RMeta => "RMeta",
+
+        K::Enter => "Enter",
+        K::Up => "Up",
+        K::Down => "Down",
+        K::Left => "Left",
+        K::Right => "Right",
+
+        K::Backspace => "Backspc",
+
+        K::CapsLock => "CapsLock",
+        K::Tab => "Tab",
+        K::Home => "Home",
+        K::End => "End",
+        K::PageUp => "PageUp",
+        K::PageDown => "PageDown",
+        K::Insert => "Insert",
+        K::Delete => "Delete",
+
+        K::Numpad0 => "Num0", K::Numpad1 => "Num1", K::Numpad2 => "Num2",
+        K::Numpad3 => "Num3", K::Numpad4 => "Num4", K::Numpad5 => "Num5",
+        K::Numpad6 => "Num6", K::Numpad7 => "Num7", K::Numpad8 => "Num8",
+        K::Numpad9 => "Num9",
+        K::NumpadSubtract => "Num-",
+        K::NumpadAdd => "Num+",
+        K::NumpadDivide => "Num/",
+        K::NumpadMultiply => "Num*",
+        // No rdev/dropdown counterpart used in this app.
+        K::NumpadEquals => "Num=",
+        K::NumpadEnter => "NumEnt",
+        K::NumpadDecimal => "Num.",
+
+        K::Grave => "`",
+        K::Minus => "-",
+        K::Equal => "=",
+        K::LeftBracket => "[",
+        K::RightBracket => "]",
+        K::BackSlash => "\\",
+        K::Semicolon => ";",
+        K::Apostrophe => "'",
+        K::Comma => ",",
+        K::Dot => ".",
+        K::Slash => "/",
+    }
+}
+
+/// Map a globally-polled `device_query::Keycode` (used for hotkeys) to the
+/// `rdev::Key` it represents (used for the simulated click button), so a
+/// physically-pressed key can be used to select a click button directly
+/// instead of scrolling the dropdown in `gui/sections/buttons.rs`.
+///
+/// Returns `None` for keys that either have no `rdev::Key` counterpart
+/// offered in the click-button dropdown, or that `device_query` can't
+/// report at all (e.g. PrintScreen/ScrollLock/Pause/NumLock aren't polled
+/// by `device_query`, so they can never reach this function from a live
+/// key-press — the dropdown remains the only way to select those).
+/// Callers should fall back to the manual dropdown when this returns `None`.
+pub fn keycode_to_rdev_key(keycode: Keycode) -> Option<Key> {
+    use Keycode as K;
+    Some(match keycode {
+        K::Key0 => Key::Num0,
+        K::Key1 => Key::Num1,
+        K::Key2 => Key::Num2,
+        K::Key3 => Key::Num3,
+        K::Key4 => Key::Num4,
+        K::Key5 => Key::Num5,
+        K::Key6 => Key::Num6,
+        K::Key7 => Key::Num7,
+        K::Key8 => Key::Num8,
+        K::Key9 => Key::Num9,
+
+        K::A => Key::KeyA,
+        K::B => Key::KeyB,
+        K::C => Key::KeyC,
+        K::D => Key::KeyD,
+        K::E => Key::KeyE,
+        K::F => Key::KeyF,
+        K::G => Key::KeyG,
+        K::H => Key::KeyH,
+        K::I => Key::KeyI,
+        K::J => Key::KeyJ,
+        K::K => Key::KeyK,
+        K::L => Key::KeyL,
+        K::M => Key::KeyM,
+        K::N => Key::KeyN,
+        K::O => Key::KeyO,
+        K::P => Key::KeyP,
+        K::Q => Key::KeyQ,
+        K::R => Key::KeyR,
+        K::S => Key::KeyS,
+        K::T => Key::KeyT,
+        K::U => Key::KeyU,
+        K::V => Key::KeyV,
+        K::W => Key::KeyW,
+        K::X => Key::KeyX,
+        K::Y => Key::KeyY,
+        K::Z => Key::KeyZ,
+
+        K::F1 => Key::F1,
+        K::F2 => Key::F2,
+        K::F3 => Key::F3,
+        K::F4 => Key::F4,
+        K::F5 => Key::F5,
+        K::F6 => Key::F6,
+        K::F7 => Key::F7,
+        K::F8 => Key::F8,
+        K::F9 => Key::F9,
+        K::F10 => Key::F10,
+        K::F11 => Key::F11,
+        K::F12 => Key::F12,
+
+        K::Escape => Key::Escape,
+        K::Space => Key::Space,
+
+        K::LControl => Key::ControlLeft,
+        K::RControl => Key::ControlRight,
+        K::LShift => Key::ShiftLeft,
+        K::RShift => Key::ShiftRight,
+        K::LAlt => Key::Alt,
+        K::RAlt => Key::AltGr,
+        K::LMeta => Key::MetaLeft,
+        K::RMeta => Key::MetaRight,
+
+        K::Enter => Key::Return,
+        K::Up => Key::UpArrow,
+        K::Down => Key::DownArrow,
+        K::Left => Key::LeftArrow,
+        K::Right => Key::RightArrow,
+
+        K::CapsLock => Key::CapsLock,
+        K::Tab => Key::Tab,
+        K::Home => Key::Home,
+        K::End => Key::End,
+        K::PageUp => Key::PageUp,
+        K::PageDown => Key::PageDown,
+        K::Insert => Key::Insert,
+        K::Delete => Key::Delete,
+        // Was previously missing from this table entirely, which is what
+        // caused a captured Backspace to wrongly report "not supported for
+        // auto-capture" — device_query DOES report Backspace fine; it's
+        // rdev::Key::Backspace that just wasn't in the dropdown yet either.
+        // Both are now wired up (see the dropdown/key_names! list and the
+        // abbreviation tables).
+        K::Backspace => Key::Backspace,
+
+        K::Numpad0 => Key::Kp0,
+        K::Numpad1 => Key::Kp1,
+        K::Numpad2 => Key::Kp2,
+        K::Numpad3 => Key::Kp3,
+        K::Numpad4 => Key::Kp4,
+        K::Numpad5 => Key::Kp5,
+        K::Numpad6 => Key::Kp6,
+        K::Numpad7 => Key::Kp7,
+        K::Numpad8 => Key::Kp8,
+        K::Numpad9 => Key::Kp9,
+        K::NumpadSubtract => Key::KpMinus,
+        K::NumpadAdd => Key::KpPlus,
+        K::NumpadDivide => Key::KpDivide,
+        K::NumpadMultiply => Key::KpMultiply,
+        K::NumpadEnter => Key::KpReturn,
+        // rdev has no separate "decimal" numpad key — on most keyboards
+        // this physical key reports as Delete when Num Lock is off and as
+        // a digit/decimal-point when it's on, and rdev only models the
+        // Delete side of that (`KpDelete`). This was previously missing
+        // too, causing the same false "not supported" error as Backspace.
+        K::NumpadDecimal => Key::KpDelete,
+
+        K::Grave => Key::BackQuote,
+        K::Minus => Key::Minus,
+        K::Equal => Key::Equal,
+        K::LeftBracket => Key::LeftBracket,
+        K::RightBracket => Key::RightBracket,
+        K::BackSlash => Key::BackSlash,
+        K::Semicolon => Key::SemiColon,
+        K::Apostrophe => Key::Quote,
+        K::Comma => Key::Comma,
+        K::Dot => Key::Dot,
+        K::Slash => Key::Slash,
+
+        // No rdev::Key counterpart offered in the dropdown (NumpadEquals,
+        // Command/RCommand/LOption/ROption, F13+): fall back to manual
+        // selection. These genuinely have no equivalent, unlike Backspace
+        // and NumpadDecimal above.
+        _ => return None,
+    })
+}
 
 /// Load icon from memory and return it
 pub fn load_icon() -> eframe::egui::IconData {


### PR DESCRIPTION
## Coordinate Picker

- Fixed the picker window drifting away from the cursor on high-DPI displays — it was using physical pixel coordinates where egui expected logical (scaled) points.
- Picker now centers horizontally under the cursor and sits a fixed gap below it (instead of a diagonal offset), and is clamped to the current monitor so it can no longer get cut off near screen edges.
- Picker retains its own `always_on_top` (unchanged) — it needs to stay visible above whatever window you're picking coordinates from. This is deliberately separate from the main window (see below).

## Click Button: Keyboard Key Capture

- Added a "Press Key" capture flow for the keyboard click-button — press a key instead of scrolling the dropdown to find it.
- Capture rejects keys already bound to an existing hotkey (Start/Stop, Set Coords, Confirm Coords, Hold), with an inline error explaining the conflict, rather than silently creating an ambiguous double-binding.
- Manual dropdown selection kept as a fallback for keys `device_query` can't detect live (Num Lock, Print Screen, Scroll Lock, Pause — these don't exist in that crate's `Keycode` enum at all, on any platform).
- Fixed Backspace and the numpad `.`/Delete key both being wrongly reported as "not supported for auto-capture" — both are actually detectable; they were just missing from the internal key-mapping table (and Backspace was missing from the dropdown entirely).
- The selected keyboard key is now remembered across Mouse↔Keyboard toggling instead of resetting to Space every time; persisted on Save, reset to Space by the Reset button.
- "Set to X" confirmation now fires consistently for both the dropdown and Press-Key capture (previously only capture showed it, and inconsistently), clears when switching to Mouse mode, and auto-clears after 5 seconds.

## Consistent Key Abbreviations

- Unified how key names are displayed everywhere (hotkey bar, Hotkeys window, click-button dropdown, capture feedback) — previously the same physical key could show as `KeyF` in one place and `F` in another.
- Long names abbreviated to ≤8 characters (`NumpadDecimal` → `Num.`, `ControlLeft` → `LCtrl`, etc.); short/common names kept as full words (`Escape`, `Space`, `Enter`, `Delete`, etc.).

## Click Mode Section

- Renamed "Click Position" → "Click Mode"; renamed "Coords" → "Fixed" (the "Set Coords" button itself is unchanged).
- Swapped layout: Mouse/Fixed toggle moved to the left (previously where Set Coords sat), Set Coords + X/Y fields moved right.
- Single/Double click-type order fixed to read left-to-right as intended.
- Fixed a layout bug where the click-key feedback row could corrupt egui's row-height bookkeeping, producing a large blank gap that pushed all content below it down or off-window.

## Random Offset (Click Interval)

- Added an optional "Random Offset (+/-)" control next to Click Interval — when enabled, applies a random jitter (in ms, default range 40) to each click's actual interval instead of firing at a perfectly fixed cadence.
- Off by default; disabled state leaves click timing exactly as before.
- Setting persisted (Save/load), reset to default by the Reset button; backward-compatible with existing `settings.json` files that predate this field.

## Window Behavior

- Main window no longer force-topmost (`always_on_top` removed) — it now behaves like a normal window and can be covered by other apps. The picker's own `always_on_top` is untouched (see above).
- Minimum window size now enforced at the OS level (`with_min_inner_size`), so the window can no longer be resized into an unusable degenerate state — a real bug we hit during testing, which also corrupted the saved window size in `settings.json` on close and required manually deleting the file to recover.
- Added an in-app note ("Hold HotKeys*" with hover tooltip) explaining that a quick tap of a hotkey may occasionally not register while the window is minimized, and a long-press is more reliable in that case — see Known Limitation below.

## Responsive UI

- The layout now scales as a single unit (fonts, spacing, control sizing) with window size, via a `ui_scale` factor recomputed every frame, instead of using fixed pixel values throughout.
- Settings rows bound their right-aligned controls to actual remaining row width, fixing text clipping ("Humanlike"/"px/s" etc.) at smaller window sizes.
- Start/Hold buttons now size themselves to their own label content — measured via egui's actual font metrics rather than a fixed pixel width — so long hotkey labels (e.g. "STOP (Num Lock)") no longer clip.
- Minor text polish: "Humanlike" → "Human" (space-constrained context), "Hotkeys" → "HotKeys" for consistency.
- Scale is clamped between 0.7× and 1.5× — at very large window sizes, extra space below the (capped) content is expected, not a bug.

## Known Limitation (not fixed in this version)

- On some systems, a *very quick* tap of a hotkey may occasionally not register while the app is minimized (a longer press registers reliably). Root-caused to the OS throttling a minimized window's event loop, which intermittently delays this app's own frame processing. A real fix likely requires either moving state ownership (not just input detection) off the GUI thread, or a genuine OS-level global-hotkey hook in place of polling — both larger undertakings than fit in this PR. The in-app note above sets expectations in the meantime.

## Misc

- Version bumped to 2.5.6.
- Fixed a `clippy::collapsible_if` warning in `app.rs`.
- `cargo build` and `cargo clippy` clean.